### PR TITLE
Harden delete IPC and enable renderer sandboxing

### DIFF
--- a/electron/core/ipc.cjs
+++ b/electron/core/ipc.cjs
@@ -1,5 +1,4 @@
 const { ipcMain, shell } = require('electron')
-const sudo = require('sudo-prompt')
 const { scanAllCategories } = require('./scanners.cjs')
 
 function registerIpcHandlers(getWindow) {
@@ -11,30 +10,27 @@ function registerIpcHandlers(getWindow) {
     return items
   })
 
-  ipcMain.handle('delete-items', async (_evt, paths) => {
-    let deleted = 0, failed = 0
-    for (const p of paths) {
+  ipcMain.handle('delete-items', async (_evt, paths = []) => {
+    const safePaths = Array.isArray(paths) ? paths.filter((p) => typeof p === 'string') : []
+    let deleted = 0
+    const failed = []
+
+    for (const p of safePaths) {
       try {
         await shell.trashItem(p)
         deleted++
-      } catch (e) {
-        try {
-          await new Promise((resolve, reject) => {
-            const options = { name: 'CleanMyMac Pro (React)' }
-            sudo.exec(`rm -rf "${p.replace(/"/g, '\\"')}"`, options, (error) => {
-              if (error) reject(error); else resolve()
-            })
-          })
-          deleted++
-        } catch {
-          failed++
-        }
+      } catch (error) {
+        failed.push({
+          path: p,
+          message: error instanceof Error
+            ? error.message
+            : 'Não foi possível mover para a Lixeira. O sistema bloqueou esta remoção.'
+        })
       }
     }
+
     return { deleted, failed }
   })
 }
 
 module.exports = { registerIpcHandlers }
-
-

--- a/electron/core/window.cjs
+++ b/electron/core/window.cjs
@@ -9,12 +9,11 @@ function createMainWindow(isDev) {
             preload: path.join(__dirname, '..', 'preload.cjs'),
             contextIsolation: true,
             nodeIntegration: false,
-            sandbox: false
+            sandbox: true
         }
     })
     return win
 }
 
 module.exports = { createMainWindow }
-
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,7 +1,10 @@
 const { contextBridge, ipcRenderer } = require('electron')
 contextBridge.exposeInMainWorld('cleaner', {
   scanAll: () => ipcRenderer.invoke('scan-all'),
-  deleteItems: (paths) => ipcRenderer.invoke('delete-items', paths),
+  deleteItems: (paths) => ipcRenderer.invoke(
+    'delete-items',
+    Array.isArray(paths) ? paths.filter((p) => typeof p === 'string') : []
+  ),
   onScanProgress: (cb) => {
     const handler = (_, value) => cb(value)
     ipcRenderer.on('scan-progress', handler)

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -2,7 +2,10 @@ import { contextBridge, ipcRenderer } from 'electron'
 
 contextBridge.exposeInMainWorld('cleaner', {
   scanAll: () => ipcRenderer.invoke('scan-all'),
-  deleteItems: (paths: string[]) => ipcRenderer.invoke('delete-items', paths),
+  deleteItems: (paths: string[]) => ipcRenderer.invoke(
+    'delete-items',
+    Array.isArray(paths) ? paths.filter((p) => typeof p === 'string') : []
+  ),
   onScanProgress: (cb: (progress: number) => void) => {
     const handler = (_: unknown, value: number) => cb(value)
     ipcRenderer.on('scan-progress', handler)

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "lucide-react": "^0.542.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "sudo-prompt": "^9.2.1",
         "tailwind-merge": "^3.3.1",
         "uuid": "^9.0.1"
       },
@@ -7263,13 +7262,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/sudo-prompt": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
-      "integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT"
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "lucide-react": "^0.542.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sudo-prompt": "^9.2.1",
     "tailwind-merge": "^3.3.1",
     "uuid": "^9.0.1"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,7 +50,20 @@ export default function App() {
     const ok = confirm(`Tem certeza que deseja deletar ${selectedList.length} itens?\n\nEspaço a ser liberado: ${formatBytes(selectedSize)}`)
     if (!ok) return
     const { deleted, failed } = await window.cleaner.deleteItems(selectedList.map(i => i.path))
-    alert(`Limpeza concluída. Removidos: ${deleted}, falhas: ${failed}.`)
+    if (failed.length > 0) {
+      const details = failed
+        .slice(0, 3)
+        .map((entry) => `• ${entry.path}\n  Motivo: ${entry.message}`)
+        .join('\n\n')
+      const extra = failed.length > 3 ? `\n\n...e mais ${failed.length - 3} item(ns) com restrição do sistema.` : ''
+      alert(
+        `Limpeza parcial concluída.\n\nRemovidos: ${deleted}\nBloqueados pelo sistema: ${failed.length}\n\n` +
+        'Alguns arquivos não podem ser removidos sem permissões adicionais ou porque estão protegidos pelo macOS.\n\n' +
+        `${details}${extra}`
+      )
+    } else {
+      alert(`Limpeza concluída com sucesso. Removidos: ${deleted}.`)
+    }
     // Remove from local state
     const kept = items.filter(i => !selected[i.id])
     setItems(kept)
@@ -194,4 +207,3 @@ export default function App() {
     </div>
   )
 }
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ declare global {
   interface Window {
     cleaner?: {
       scanAll: () => Promise<CleanupItem[]>
-      deleteItems: (paths: string[]) => Promise<{ deleted: number, failed: number }>
+      deleteItems: (paths: string[]) => Promise<{ deleted: number, failed: { path: string, message: string }[] }>
       onScanProgress: (cb: (progress: number) => void) => () => void
     }
   }
@@ -63,5 +63,4 @@ export const CATEGORY_INFO: Record<CleanupCategory, CategoryInfo> = {
 export const CATEGORY_ORDER: CleanupCategory[] = [
   'Cache', 'Logs', 'Temporary', 'Old Downloads', 'Browser Cache', 'App Support'
 ]
-
 


### PR DESCRIPTION
### Motivation
- Remove privileged fallback removal using `sudo-prompt` and ensure deletions go through supported, safe APIs only.
- Prevent renderer from relying on Node permissions by enabling renderer sandboxing and tightening the preload bridge.
- Surface clear, per-item failure information to the user when system restrictions block removal.

### Description
- Removed `sudo-prompt` usage and the `sudo.exec(...)` fallback from the CJS IPC handler, keeping deletion attempts to `shell.trashItem` only and returning explicit per-item failures as `{ path, message }` (file: `electron/core/ipc.cjs`).
- Enabled renderer sandboxing by setting `webPreferences.sandbox = true` in the BrowserWindow creation (file: `electron/core/window.cjs`).
- Hardened the preload bridge to sanitize `deleteItems` input so only string paths are forwarded to the main process, in both CJS and TS preload files (files: `electron/preload.cjs`, `electron/preload.ts`).
- Updated renderer typings to reflect the new failure shape and revised UI messaging in `src/App.tsx` to explain when files are blocked by system restrictions and show short failure details.
- Removed `sudo-prompt` from `package.json` and updated the lockfile to match the new dependency set.

### Testing
- Built the renderer with `npm run build:react` and the build completed successfully.
- Verified repository state and applied changes were committed (local commit performed during the rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4125486908330b7e8d17e690bc4cf)