### PR TITLE
Add MAS/MAS-DEV build channels, entitlements and App Store metadata validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,62 @@ npm run dev
 
 This starts Vite (React) and Electron together. The app will open automatically.
 
-## Build a macOS DMG
+## Build channels (DMG / Mac App Store)
+
+### 1) Direct distribution (DMG)
 
 ```bash
-npm run make:mac
+npm run build:dmg
 ```
 
-The DMG will appear under `dist/` packaged by electron-builder.
+### 2) Mac App Store (production)
+
+```bash
+npm run build:mas
+```
+
+### 3) Mac App Store (development / TestFlight local signing checks)
+
+```bash
+npm run build:mas-dev
+```
+
+### Optional: build all defaults
+
+```bash
+npm run build:all
+```
+
+Artifacts are generated under `dist/` by `electron-builder`.
+
+## Signing & provisioning in CI (environment variables)
+
+The build is parameterized to avoid hardcoding identities/profiles:
+
+- `CSC_NAME`: macOS signing identity used by DMG, MAS and MAS-DEV.
+- `MAC_PROVISIONING_PROFILE`: provisioning profile path/identifier for direct mac build (if needed by your signing flow).
+- `MAS_PROVISIONING_PROFILE`: provisioning profile path/identifier for Mac App Store distribution.
+- `MAS_DEV_PROVISIONING_PROFILE`: provisioning profile path/identifier for Mac App Store development builds.
+
+Entitlements files used by MAS builds:
+
+- `build/entitlements.mas.plist`
+- `build/entitlements.mas.inherit.plist`
+
+## Metadata validation for App Store Connect consistency
+
+Before publishing, run:
+
+```bash
+npm run validate:metadata
+```
+
+This check validates:
+
+- `build.appId` format (reverse-DNS).
+- `version` in semver-compatible format.
+- `build.mac.category` against known Apple categories.
+- Category consistency across `mac`, `mas`, and `masDev` targets.
 
 ## Notes & Permissions
 

--- a/build/entitlements.mas.inherit.plist
+++ b/build/entitlements.mas.inherit.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+  </dict>
+</plist>

--- a/build/entitlements.mas.plist
+++ b/build/entitlements.mas.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+  </dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -8,10 +8,13 @@
   "scripts": {
     "dev": "concurrently -k \"vite\" \"wait-on tcp:5173 && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 electron .\"",
     "build:react": "vite build",
-    "build": "vite build && electron-builder",
     "start": "electron .",
     "lint": "echo \"(add your linter here)\"",
-    "make:mac": "vite build && electron-builder --mac"
+    "build:all": "vite build && electron-builder",
+    "build:mas": "vite build && electron-builder --mac mas",
+    "build:mas-dev": "vite build && electron-builder --mac mas-dev",
+    "build:dmg": "vite build && electron-builder --mac dmg",
+    "validate:metadata": "node scripts/validate-app-store-metadata.mjs"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",
@@ -60,6 +63,27 @@
       "target": [
         "dmg"
       ],
+      "category": "public.app-category.utilities",
+      "identity": "${env.CSC_NAME}",
+      "provisioningProfile": "${env.MAC_PROVISIONING_PROFILE}",
+      "hardenedRuntime": false,
+      "entitlements": "build/entitlements.mas.plist",
+      "entitlementsInherit": "build/entitlements.mas.inherit.plist"
+    },
+    "mas": {
+      "type": "distribution",
+      "identity": "${env.CSC_NAME}",
+      "provisioningProfile": "${env.MAS_PROVISIONING_PROFILE}",
+      "entitlements": "build/entitlements.mas.plist",
+      "entitlementsInherit": "build/entitlements.mas.inherit.plist",
+      "category": "public.app-category.utilities"
+    },
+    "masDev": {
+      "type": "development",
+      "identity": "${env.CSC_NAME}",
+      "provisioningProfile": "${env.MAS_DEV_PROVISIONING_PROFILE}",
+      "entitlements": "build/entitlements.mas.plist",
+      "entitlementsInherit": "build/entitlements.mas.inherit.plist",
       "category": "public.app-category.utilities"
     }
   }

--- a/scripts/validate-app-store-metadata.mjs
+++ b/scripts/validate-app-store-metadata.mjs
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+
+const packageJson = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const { version, build = {} } = packageJson;
+const {
+  appId,
+  mac = {},
+  mas = {},
+  masDev = {}
+} = build;
+
+const errors = [];
+
+if (!appId || !/^([A-Za-z0-9-]+\.)+[A-Za-z0-9-]+$/.test(appId)) {
+  errors.push('build.appId ausente ou inválido (esperado reverse-DNS, ex: com.company.app).');
+}
+
+if (!version || !/^\d+\.\d+\.\d+([-.][A-Za-z0-9.]+)?$/.test(version)) {
+  errors.push('version ausente ou fora do padrão semver esperado pela App Store Connect.');
+}
+
+const allowedCategories = new Set([
+  'public.app-category.business',
+  'public.app-category.developer-tools',
+  'public.app-category.education',
+  'public.app-category.entertainment',
+  'public.app-category.finance',
+  'public.app-category.games',
+  'public.app-category.graphics-design',
+  'public.app-category.healthcare-fitness',
+  'public.app-category.lifestyle',
+  'public.app-category.medical',
+  'public.app-category.music',
+  'public.app-category.news',
+  'public.app-category.photography',
+  'public.app-category.productivity',
+  'public.app-category.reference',
+  'public.app-category.social-networking',
+  'public.app-category.sports',
+  'public.app-category.travel',
+  'public.app-category.utilities',
+  'public.app-category.video',
+  'public.app-category.weather'
+]);
+
+const category = mac.category;
+if (!category || !allowedCategories.has(category)) {
+  errors.push('build.mac.category ausente ou não está na lista de categorias aceitas pela Apple.');
+}
+
+if (mas.category && mas.category !== category) {
+  errors.push('build.mas.category precisa ser igual a build.mac.category.');
+}
+
+if (masDev.category && masDev.category !== category) {
+  errors.push('build.masDev.category precisa ser igual a build.mac.category.');
+}
+
+if (errors.length > 0) {
+  console.error('❌ Validação de metadados falhou:');
+  for (const error of errors) {
+    console.error(` - ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log('✅ Metadados validados: appId, versão e categoria estão consistentes para App Store Connect.');
+console.log(`appId: ${appId}`);
+console.log(`version: ${version}`);
+console.log(`category: ${category}`);


### PR DESCRIPTION
### Motivation
- Add explicit Mac App Store publishing support (production and development) while keeping the existing DMG/direct-distribution flow. 
- Avoid hardcoding signing identities/provisioning by parameterizing them via CI environment variables. 
- Provide minimal entitlements required for MAS sandboxing and a metadata validation step to reduce App Store Connect rejections. 

### Description
- Updated `package.json` to add channel-specific npm scripts `build:dmg`, `build:mas`, `build:mas-dev`, `build:all` and `validate:metadata`, and to keep `dmg` as the default `mac.target`. 
- Extended `build` configuration in `package.json` to include `mas` and `masDev` targets and to reference signing identity/provisioning via environment variables (`CSC_NAME`, `MAC_PROVISIONING_PROFILE`, `MAS_PROVISIONING_PROFILE`, `MAS_DEV_PROVISIONING_PROFILE`). 
- Added minimal entitlements files `build/entitlements.mas.plist` and `build/entitlements.mas.inherit.plist` to enable App Sandbox and user-selected read/write where appropriate. 
- Added `scripts/validate-app-store-metadata.mjs` which validates `build.appId` (reverse-DNS), `version` (semver-like), and `build.mac.category` consistency across `mac`, `mas`, and `masDev` targets. 
- Documented channel build commands, required CI environment variables, entitlements files, and metadata validation instructions in `README.md`. 

### Testing
- Ran `npm run validate:metadata` which succeeded and printed validated `appId`, `version` and `category`. 
- Built the renderer bundle with `npm run build:react` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41466f5dc833085e1c6c32c9da702)