### PR TITLE
Add sandbox-aware scan scope selection, scan profiles and permission reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,14 @@ This check validates:
 - `build.mac.category` against known Apple categories.
 - Category consistency across `mac`, `mas`, and `masDev` targets.
 
-## Notes & Permissions
+## Privacy, Permissions & Scan Scope
 
-- Some locations like `/Library/...` may require admin rights to delete. The app uses `trash` whenever possible.
-- For broader read access (e.g. full Application Support), you may need to grant **Full Disk Access** in System Settings → Privacy & Security.
-- This template avoids Node integration in the renderer and exposes only a minimal API via `preload` for better security.
+- O app agora só analisa diretórios autorizados pelo usuário em **“Selecionar pasta para análise”**.
+- As permissões autorizadas e o perfil de análise são persistidos em `userData/scan-settings.json` no sandbox do app.
+- Perfis de scan disponíveis:
+  - **Rápido**: categorias essenciais e menor superfície de leitura.
+  - **Seguro**: equilíbrio entre cobertura e redução de acessos negados.
+  - **Completo**: cobertura máxima das categorias suportadas.
+- Diretórios não analisados por permissão insuficiente são exibidos na interface, em vez de falha silenciosa.
+- A remoção continua usando envio para a Lixeira (`shell.trashItem`) sempre que permitido pelo sistema.
+- O app mantém Node desabilitado no renderer e expõe somente API mínima via `preload`.

--- a/electron/core/ipc.cjs
+++ b/electron/core/ipc.cjs
@@ -1,13 +1,94 @@
-const { ipcMain, shell } = require('electron')
-const { scanAllCategories } = require('./scanners.cjs')
+const { ipcMain, shell, dialog, app } = require('electron')
+const path = require('node:path')
+const fs = require('node:fs/promises')
+const { SCAN_PROFILES, scanAllCategories } = require('./scanners.cjs')
+
+const DEFAULT_SETTINGS = {
+  authorizedDirectories: [app.getPath('home')],
+  scanProfile: 'safe'
+}
+
+function getSettingsPath() {
+  return path.join(app.getPath('userData'), 'scan-settings.json')
+}
+
+async function loadScanSettings() {
+  try {
+    const raw = await fs.readFile(getSettingsPath(), 'utf-8')
+    const parsed = JSON.parse(raw)
+    const authorizedDirectories = Array.isArray(parsed.authorizedDirectories)
+      ? parsed.authorizedDirectories.filter((entry) => typeof entry === 'string')
+      : DEFAULT_SETTINGS.authorizedDirectories
+    const scanProfile = Object.hasOwn(SCAN_PROFILES, parsed.scanProfile) ? parsed.scanProfile : DEFAULT_SETTINGS.scanProfile
+    return { authorizedDirectories, scanProfile }
+  } catch {
+    return { ...DEFAULT_SETTINGS }
+  }
+}
+
+async function saveScanSettings(settings) {
+  await fs.mkdir(app.getPath('userData'), { recursive: true })
+  await fs.writeFile(getSettingsPath(), JSON.stringify(settings, null, 2), 'utf-8')
+  return settings
+}
+
+async function addAuthorizedDirectory() {
+  const result = await dialog.showOpenDialog({
+    title: 'Selecionar pasta para análise',
+    properties: ['openDirectory', 'createDirectory']
+  })
+
+  if (result.canceled || !result.filePaths.length) return null
+
+  const selectedPath = path.resolve(result.filePaths[0])
+  const currentSettings = await loadScanSettings()
+  const nextDirectories = Array.from(new Set([...currentSettings.authorizedDirectories, selectedPath]))
+
+  return saveScanSettings({
+    ...currentSettings,
+    authorizedDirectories: nextDirectories
+  })
+}
 
 function registerIpcHandlers(getWindow) {
   ipcMain.handle('scan-all', async () => {
     const win = getWindow()
-    const items = await scanAllCategories((p) => {
-      if (win) win.webContents.send('scan-progress', p)
+    const settings = await loadScanSettings()
+
+    return scanAllCategories({
+      allowedRoots: settings.authorizedDirectories,
+      profile: settings.scanProfile,
+      onProgress: (p) => {
+        if (win) win.webContents.send('scan-progress', p)
+      }
     })
-    return items
+  })
+
+  ipcMain.handle('scan-settings:get', async () => loadScanSettings())
+
+  ipcMain.handle('scan-settings:add-directory', async () => addAuthorizedDirectory())
+
+  ipcMain.handle('scan-settings:remove-directory', async (_evt, targetPath) => {
+    const settings = await loadScanSettings()
+    if (typeof targetPath !== 'string') return settings
+
+    const normalizedTarget = path.resolve(targetPath)
+    const authorizedDirectories = settings.authorizedDirectories.filter((entry) => path.resolve(entry) !== normalizedTarget)
+
+    return saveScanSettings({
+      ...settings,
+      authorizedDirectories: authorizedDirectories.length > 0 ? authorizedDirectories : [app.getPath('home')]
+    })
+  })
+
+  ipcMain.handle('scan-settings:set-profile', async (_evt, profile) => {
+    if (!Object.hasOwn(SCAN_PROFILES, profile)) return loadScanSettings()
+
+    const settings = await loadScanSettings()
+    return saveScanSettings({
+      ...settings,
+      scanProfile: profile
+    })
   })
 
   ipcMain.handle('delete-items', async (_evt, paths = []) => {

--- a/electron/core/scanners.cjs
+++ b/electron/core/scanners.cjs
@@ -1,18 +1,100 @@
 const path = require('node:path')
 const os = require('node:os')
+const fs = require('node:fs/promises')
 const { v4: uuidv4 } = require('uuid')
-const { getDirectorySize, listDirectoryOnce, statSafe, olderThan } = require('./fs.cjs')
+const { getDirectorySize, statSafe, olderThan } = require('./fs.cjs')
+
+const SCAN_PROFILES = {
+    quick: ['Cache', 'Logs', 'Old Downloads'],
+    safe: ['Cache', 'Logs', 'Temporary', 'Old Downloads', 'Browser Cache'],
+    complete: ['Cache', 'Logs', 'Temporary', 'Old Downloads', 'Browser Cache', 'App Support']
+}
+
+function normalizePath(targetPath) {
+    return path.resolve(targetPath)
+}
+
+function isPathWithin(root, target) {
+    const normalizedRoot = normalizePath(root)
+    const normalizedTarget = normalizePath(target)
+    const rel = path.relative(normalizedRoot, normalizedTarget)
+    return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel))
+}
+
+function buildCategoryTargets() {
+    const home = os.homedir()
+    return {
+        'Cache': [path.join(home, 'Library', 'Caches'), '/Library/Caches'],
+        'Logs': [path.join(home, 'Library', 'Logs'), '/Library/Logs'],
+        'Temporary': ['/tmp', path.join(home, '.Trash')],
+        'Old Downloads': [path.join(home, 'Downloads')],
+        'Browser Cache': [
+            path.join(home, 'Library', 'Caches', 'com.apple.Safari'),
+            path.join(home, 'Library', 'Caches', 'Google', 'Chrome'),
+            path.join(home, 'Library', 'Caches', 'Firefox')
+        ],
+        'App Support': [path.join(home, 'Library', 'Application Support')]
+    }
+}
+
+function resolveTargetsForCategory(category, allowedRoots) {
+    const candidates = buildCategoryTargets()[category] || []
+    const normalizedAllowedRoots = allowedRoots.map(normalizePath)
+
+    const allowed = []
+    const blocked = []
+
+    for (const candidate of candidates) {
+        const normalizedCandidate = normalizePath(candidate)
+        const hasPermission = normalizedAllowedRoots.some((root) => isPathWithin(root, normalizedCandidate))
+
+        if (hasPermission) {
+            allowed.push(normalizedCandidate)
+        } else {
+            blocked.push({
+                category,
+                path: normalizedCandidate,
+                reason: 'Permissão insuficiente para diretório fora do escopo autorizado.'
+            })
+        }
+    }
+
+    return { allowed, blocked }
+}
+
+async function listDirectoryDetailed(dir) {
+    try {
+        const names = await fs.readdir(dir, { withFileTypes: true })
+        return {
+            entries: names.map((d) => ({ name: d.name, isDir: d.isDirectory(), full: path.join(dir, d.name) })),
+            error: null
+        }
+    } catch (error) {
+        return { entries: [], error }
+    }
+}
 
 async function scanGroup(dirs, category, opts = {}, onSubProgress = null) {
     const out = []
-    let totalDirs = dirs.length
+    const skipped = []
+    const totalDirs = dirs.length || 1
     let processedDirs = 0
-    
+
     for (const dir of dirs) {
-        const items = await listDirectoryOnce(dir)
-        let totalItems = items.length
+        const { entries: items, error } = await listDirectoryDetailed(dir)
+        if (error) {
+            const reason = error && error.code === 'EACCES'
+                ? 'Permissão de leitura negada pelo sistema.'
+                : 'Diretório não pôde ser analisado.'
+            skipped.push({ category, path: dir, reason })
+            processedDirs++
+            if (onSubProgress) onSubProgress(processedDirs / totalDirs)
+            continue
+        }
+
+        const totalItems = items.length || 1
         let processedItems = 0
-        
+
         for (const entry of items) {
             const st = await statSafe(entry.full)
             if (!st) {
@@ -69,7 +151,7 @@ async function scanGroup(dirs, category, opts = {}, onSubProgress = null) {
                 category,
                 lastModified: st.mtimeMs
             })
-            
+
             processedItems++
             if (onSubProgress) {
                 const dirProgress = processedItems / totalItems
@@ -80,80 +162,50 @@ async function scanGroup(dirs, category, opts = {}, onSubProgress = null) {
         processedDirs++
     }
     out.sort((a, b) => b.size - a.size)
-    return out
+    return { items: out, skipped }
 }
 
-async function scanCache(onSubProgress = null) {
-    const home = os.homedir()
-    const targets = [path.join(home, 'Library', 'Caches'), '/Library/Caches']
-    return scanGroup(targets, 'Cache', {}, onSubProgress)
+function buildCategoryOptions(category) {
+    if (category === 'Logs') return { extensions: ['log', 'txt'] }
+    if (category === 'Old Downloads') {
+        const cutoff = Date.now() - 30 * 24 * 60 * 60 * 1000
+        return { olderThanMs: cutoff }
+    }
+    if (category === 'App Support') return { minSize: 10 * 1024 * 1024 }
+    return {}
 }
 
-async function scanLogs(onSubProgress = null) {
-    const home = os.homedir()
-    const targets = [path.join(home, 'Library', 'Logs'), '/Library/Logs']
-    return scanGroup(targets, 'Logs', { extensions: ['log', 'txt'] }, onSubProgress)
-}
+async function scanAllCategories({ onProgress, allowedRoots = [], profile = 'safe' } = {}) {
+    const categories = SCAN_PROFILES[profile] || SCAN_PROFILES.safe
+    const allItems = []
+    const skipped = []
 
-async function scanTemporary(onSubProgress = null) {
-    const home = os.homedir()
-    const targets = ['/tmp', path.join(home, '.Trash')]
-    return scanGroup(targets, 'Temporary', {}, onSubProgress)
-}
+    for (let i = 0; i < categories.length; i++) {
+        const category = categories[i]
+        const categoryBaseProgress = i / categories.length
+        const categoryWeight = 1 / categories.length
 
-async function scanOldDownloads(onSubProgress = null) {
-    const home = os.homedir()
-    const downloads = path.join(home, 'Downloads')
-    const cutoff = Date.now() - 30 * 24 * 60 * 60 * 1000
-    return scanGroup([downloads], 'Old Downloads', { olderThanMs: cutoff }, onSubProgress)
-}
-
-async function scanBrowserCache(onSubProgress = null) {
-    const home = os.homedir()
-    const targets = [
-        path.join(home, 'Library', 'Caches', 'com.apple.Safari'),
-        path.join(home, 'Library', 'Caches', 'Google', 'Chrome'),
-        path.join(home, 'Library', 'Caches', 'Firefox')
-    ]
-    return scanGroup(targets, 'Browser Cache', {}, onSubProgress)
-}
-
-async function scanAppSupport(onSubProgress = null) {
-    const home = os.homedir()
-    const targets = [path.join(home, 'Library', 'Application Support')]
-    return scanGroup(targets, 'App Support', { minSize: 10 * 1024 * 1024 }, onSubProgress)
-}
-
-async function scanAllCategories(onProgress) {
-    const cats = [scanCache, scanLogs, scanTemporary, scanOldDownloads, scanBrowserCache, scanAppSupport]
-    const out = []
-    for (let i = 0; i < cats.length; i++) {
-        const categoryBaseProgress = i / cats.length
-        const categoryWeight = 1 / cats.length
-        
         const onSubProgress = onProgress ? (subProgress) => {
             const totalProgress = categoryBaseProgress + (subProgress * categoryWeight)
             onProgress(totalProgress)
         } : null
-        
-        const res = await cats[i](onSubProgress)
-        out.push(...res)
-        
-        // Ensure we reach the full category progress
-        if (onProgress) onProgress((i + 1) / cats.length)
+
+        const { allowed, blocked } = resolveTargetsForCategory(category, allowedRoots)
+        skipped.push(...blocked)
+
+        if (allowed.length > 0) {
+            const res = await scanGroup(allowed, category, buildCategoryOptions(category), onSubProgress)
+            allItems.push(...res.items)
+            skipped.push(...res.skipped)
+        }
+
+        if (onProgress) onProgress((i + 1) / categories.length)
     }
-    return out
+
+    return { items: allItems, skipped }
 }
 
 module.exports = {
-    scanGroup,
-    scanCache,
-    scanLogs,
-    scanTemporary,
-    scanOldDownloads,
-    scanBrowserCache,
-    scanAppSupport,
+    SCAN_PROFILES,
     scanAllCategories
 }
-
-

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,6 +1,10 @@
 const { contextBridge, ipcRenderer } = require('electron')
 contextBridge.exposeInMainWorld('cleaner', {
   scanAll: () => ipcRenderer.invoke('scan-all'),
+  getScanSettings: () => ipcRenderer.invoke('scan-settings:get'),
+  addAuthorizedDirectory: () => ipcRenderer.invoke('scan-settings:add-directory'),
+  removeAuthorizedDirectory: (targetPath) => ipcRenderer.invoke('scan-settings:remove-directory', targetPath),
+  setScanProfile: (profile) => ipcRenderer.invoke('scan-settings:set-profile', profile),
   deleteItems: (paths) => ipcRenderer.invoke(
     'delete-items',
     Array.isArray(paths) ? paths.filter((p) => typeof p === 'string') : []

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -2,6 +2,10 @@ import { contextBridge, ipcRenderer } from 'electron'
 
 contextBridge.exposeInMainWorld('cleaner', {
   scanAll: () => ipcRenderer.invoke('scan-all'),
+  getScanSettings: () => ipcRenderer.invoke('scan-settings:get'),
+  addAuthorizedDirectory: () => ipcRenderer.invoke('scan-settings:add-directory'),
+  removeAuthorizedDirectory: (targetPath: string) => ipcRenderer.invoke('scan-settings:remove-directory', targetPath),
+  setScanProfile: (profile: string) => ipcRenderer.invoke('scan-settings:set-profile', profile),
   deleteItems: (paths: string[]) => ipcRenderer.invoke(
     'delete-items',
     Array.isArray(paths) ? paths.filter((p) => typeof p === 'string') : []

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { CleanupCategory, CleanupItem, CATEGORY_ORDER } from './types'
+import { CleanupCategory, CleanupItem, CATEGORY_ORDER, ScanProfile, SkippedScanTarget } from './types'
 import { Header } from './components/Header'
 import { Sidebar } from './components/Sidebar'
 import { CategorySection } from './components/CategorySection'
+import { ScanScopeSelector } from './components/ScanScopeSelector'
 import { formatBytes } from './utils/format'
-import { Search, Loader2, FolderOpen } from 'lucide-react'
+import { Search, Loader2, FolderOpen, ShieldAlert } from 'lucide-react'
 
 export default function App() {
   const [items, setItems] = useState<CleanupItem[]>([])
@@ -13,11 +14,25 @@ export default function App() {
   const [progress, setProgress] = useState(0)
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [activeCategory, setActiveCategory] = useState<CleanupCategory | null>(null)
+  const [scanProfile, setScanProfile] = useState<ScanProfile>('safe')
+  const [authorizedDirectories, setAuthorizedDirectories] = useState<string[]>([])
+  const [skippedTargets, setSkippedTargets] = useState<SkippedScanTarget[]>([])
 
   useEffect(() => {
     if (!window.cleaner) return
     const off = window.cleaner.onScanProgress((p) => setProgress(p))
     return () => off && off()
+  }, [])
+
+  useEffect(() => {
+    async function loadSettings() {
+      if (!window.cleaner) return
+      const settings = await window.cleaner.getScanSettings()
+      setScanProfile(settings.scanProfile)
+      setAuthorizedDirectories(settings.authorizedDirectories)
+    }
+
+    loadSettings()
   }, [])
 
   const totalSize = useMemo(() => items.reduce((acc, it) => acc + it.size, 0), [items])
@@ -38,10 +53,34 @@ export default function App() {
     setItems([])
     setSelected({})
     setProgress(0)
+    setSkippedTargets([])
     const result = await window.cleaner.scanAll()
-    setItems(result)
+    setItems(result.items)
+    setSkippedTargets(result.skipped)
     setIsScanning(false)
     setProgress(1)
+  }
+
+  async function handleProfileChange(profile: ScanProfile) {
+    if (!window.cleaner) return
+    const settings = await window.cleaner.setScanProfile(profile)
+    setScanProfile(settings.scanProfile)
+    setAuthorizedDirectories(settings.authorizedDirectories)
+  }
+
+  async function handleAddDirectory() {
+    if (!window.cleaner) return
+    const settings = await window.cleaner.addAuthorizedDirectory()
+    if (!settings) return
+    setScanProfile(settings.scanProfile)
+    setAuthorizedDirectories(settings.authorizedDirectories)
+  }
+
+  async function handleRemoveDirectory(targetPath: string) {
+    if (!window.cleaner) return
+    const settings = await window.cleaner.removeAuthorizedDirectory(targetPath)
+    setScanProfile(settings.scanProfile)
+    setAuthorizedDirectories(settings.authorizedDirectories)
   }
 
   async function handleDelete() {
@@ -64,7 +103,6 @@ export default function App() {
     } else {
       alert(`Limpeza concluída com sucesso. Removidos: ${deleted}.`)
     }
-    // Remove from local state
     const kept = items.filter(i => !selected[i.id])
     setItems(kept)
     setSelected({})
@@ -94,15 +132,13 @@ export default function App() {
 
   return (
     <div className="flex h-screen bg-gray-50 dark:bg-gray-900 relative">
-      {/* Mobile overlay */}
       {sidebarOpen && (
-        <div 
+        <div
           className="fixed inset-0 bg-black bg-opacity-50 z-40 lg:hidden"
           onClick={() => setSidebarOpen(false)}
         />
       )}
-      
-      {/* Sidebar */}
+
       <div className={`
         transition-all duration-300 ease-in-out overflow-hidden
         lg:relative lg:z-auto
@@ -122,18 +158,42 @@ export default function App() {
         />
       </div>
 
-      {/* Main content */}
       <main className="flex-1 flex flex-col min-w-0 transition-all duration-300 ease-in-out">
-        <Header 
-          isScanning={isScanning} 
-          onScan={handleScan} 
-          canClean={selectedList.length > 0} 
+        <Header
+          isScanning={isScanning}
+          onScan={handleScan}
+          canClean={selectedList.length > 0}
           onClean={handleDelete}
           sidebarOpen={sidebarOpen}
           onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
         />
-        
-        <section className="flex-1 flex flex-col h-0 p-4 sm:p-6 lg:p-8 bg-gray-50 dark:bg-gray-900">
+
+        <section className="flex-1 flex flex-col h-0 p-4 sm:p-6 lg:p-8 bg-gray-50 dark:bg-gray-900 overflow-y-auto">
+          <ScanScopeSelector
+            profile={scanProfile}
+            directories={authorizedDirectories}
+            onProfileChange={handleProfileChange}
+            onAddDirectory={handleAddDirectory}
+            onRemoveDirectory={handleRemoveDirectory}
+            disabled={isScanning}
+          />
+
+          {skippedTargets.length > 0 && !isScanning && (
+            <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-xl p-4 mb-4">
+              <div className="flex items-center gap-2 text-amber-800 dark:text-amber-200 font-semibold text-sm">
+                <ShieldAlert className="w-4 h-4" />
+                Itens não analisados por permissão insuficiente ({skippedTargets.length})
+              </div>
+              <ul className="mt-2 space-y-1 text-xs text-amber-700 dark:text-amber-300 max-h-28 overflow-y-auto">
+                {skippedTargets.slice(0, 20).map((target) => (
+                  <li key={`${target.category}-${target.path}`}>
+                    <span className="font-semibold">[{target.category}]</span> {target.path} — {target.reason}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
           {isScanning ? (
             <div className="flex flex-col items-center justify-center h-full text-center space-y-6 px-4">
               <div className="w-16 h-16 sm:w-20 sm:h-20 lg:w-24 lg:h-24 rounded-full bg-gradient-to-br from-blue-500 to-blue-600 flex items-center justify-center shadow-lg">
@@ -145,7 +205,7 @@ export default function App() {
                   Procurando por arquivos desnecessários que podem ser removidos com segurança
                 </p>
                 <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2 mt-4">
-                  <div 
+                  <div
                     className="bg-gradient-to-r from-blue-500 to-blue-600 h-2 rounded-full transition-all duration-300 ease-out"
                     style={{ width: `${progress * 100}%` }}
                   ></div>
@@ -170,11 +230,11 @@ export default function App() {
           ) : (
             <div className="w-full max-w-6xl mx-auto flex-1 flex flex-col h-0">
               {activeCategory ? (
-                <CategorySection 
-                  category={activeCategory} 
-                  items={grouped[activeCategory]} 
-                  selected={selected} 
-                  toggle={toggle} 
+                <CategorySection
+                  category={activeCategory}
+                  items={grouped[activeCategory]}
+                  selected={selected}
+                  toggle={toggle}
                   selectAll={selectAll}
                   deselectAll={deselectAll}
                 />
@@ -191,11 +251,6 @@ export default function App() {
                       ) : (
                         'Abra a sidebar para selecionar uma categoria e visualizar os arquivos encontrados'
                       )}
-                    </p>
-                  </div>
-                  <div className="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-4 border border-blue-200 dark:border-blue-700">
-                    <p className="text-sm text-blue-700 dark:text-blue-300">
-                      💡 Dica: {sidebarOpen ? 'Use as categorias no menu lateral' : 'Abra o menu lateral'} para navegar pelos diferentes tipos de arquivos
                     </p>
                   </div>
                 </div>

--- a/src/components/ScanScopeSelector.tsx
+++ b/src/components/ScanScopeSelector.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { ScanProfile } from '../types'
+import { Shield, FolderPlus, Trash2 } from 'lucide-react'
+
+const PROFILE_OPTIONS: { value: ScanProfile, label: string, description: string }[] = [
+  { value: 'quick', label: 'Rápido', description: 'Menos categorias e menor superfície de leitura.' },
+  { value: 'safe', label: 'Seguro', description: 'Equilíbrio entre cobertura e menor risco de bloqueio.' },
+  { value: 'complete', label: 'Completo', description: 'Mais categorias, pode exigir permissões adicionais.' }
+]
+
+export function ScanScopeSelector({
+  profile,
+  directories,
+  onProfileChange,
+  onAddDirectory,
+  onRemoveDirectory,
+  disabled
+}: {
+  profile: ScanProfile
+  directories: string[]
+  onProfileChange: (profile: ScanProfile) => void
+  onAddDirectory: () => void
+  onRemoveDirectory: (targetPath: string) => void
+  disabled?: boolean
+}) {
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 mb-4 space-y-4">
+      <div className="flex items-center gap-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
+        <Shield className="w-4 h-4" />
+        Escopo de Análise e Permissões
+      </div>
+
+      <div>
+        <label className="text-xs text-gray-500 dark:text-gray-400">Perfil de scan</label>
+        <select
+          value={profile}
+          disabled={disabled}
+          onChange={(event) => onProfileChange(event.target.value as ScanProfile)}
+          className="mt-1 w-full bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-lg p-2 text-sm"
+        >
+          {PROFILE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label} — {option.description}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between">
+          <label className="text-xs text-gray-500 dark:text-gray-400">Pastas autorizadas</label>
+          <button
+            disabled={disabled}
+            onClick={onAddDirectory}
+            className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded-md bg-blue-500 hover:bg-blue-600 text-white disabled:opacity-60"
+          >
+            <FolderPlus className="w-3 h-3" />
+            Selecionar pasta para análise
+          </button>
+        </div>
+        <div className="mt-2 space-y-2 max-h-36 overflow-auto">
+          {directories.map((directory) => (
+            <div key={directory} className="flex items-center justify-between text-xs bg-gray-50 dark:bg-gray-900 rounded-lg px-2 py-2 border border-gray-200 dark:border-gray-700">
+              <span className="truncate pr-2">{directory}</span>
+              <button
+                disabled={disabled || directories.length === 1}
+                onClick={() => onRemoveDirectory(directory)}
+                className="text-red-500 hover:text-red-600 disabled:opacity-40"
+                title={directories.length === 1 ? 'Mantenha ao menos um diretório autorizado' : 'Remover diretório autorizado'}
+              >
+                <Trash2 className="w-3 h-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export type ItemType = 'file' | 'directory'
 export type CleanupCategory = 'Cache' | 'Logs' | 'Temporary' | 'Old Downloads' | 'Browser Cache' | 'App Support'
+export type ScanProfile = 'quick' | 'safe' | 'complete'
 
 export interface CategoryInfo {
   id: CleanupCategory
@@ -17,10 +18,30 @@ export interface CleanupItem {
   lastModified?: number
 }
 
+export interface SkippedScanTarget {
+  category: CleanupCategory
+  path: string
+  reason: string
+}
+
+export interface ScanResult {
+  items: CleanupItem[]
+  skipped: SkippedScanTarget[]
+}
+
+export interface ScanSettings {
+  authorizedDirectories: string[]
+  scanProfile: ScanProfile
+}
+
 declare global {
   interface Window {
     cleaner?: {
-      scanAll: () => Promise<CleanupItem[]>
+      scanAll: () => Promise<ScanResult>
+      getScanSettings: () => Promise<ScanSettings>
+      addAuthorizedDirectory: () => Promise<ScanSettings | null>
+      removeAuthorizedDirectory: (path: string) => Promise<ScanSettings>
+      setScanProfile: (profile: ScanProfile) => Promise<ScanSettings>
       deleteItems: (paths: string[]) => Promise<{ deleted: number, failed: { path: string, message: string }[] }>
       onScanProgress: (cb: (progress: number) => void) => () => void
     }
@@ -63,4 +84,3 @@ export const CATEGORY_INFO: Record<CleanupCategory, CategoryInfo> = {
 export const CATEGORY_ORDER: CleanupCategory[] = [
   'Cache', 'Logs', 'Temporary', 'Old Downloads', 'Browser Cache', 'App Support'
 ]
-


### PR DESCRIPTION
### Motivation
- Evitar leituras/varreduras silenciosamente falhas e reduzir tentativas em locais protegidos substituindo alvos fixos por diretórios autorizados pelo usuário. 
- Dar controle ao usuário sobre quais pastas o scanner pode acessar e persistir essas permissões entre execuções. 
- Reduzir erros por acesso negado oferecendo perfis de scan (rápido/seguro/completo) que limitam a superfície de leitura. 
- Informar no UI quando diretórios foram pulados por falta de permissão em vez de falhar silenciosamente.

### Description
- Refatorei o scanner em `electron/core/scanners.cjs` para suportar `SCAN_PROFILES`, resolver alvos por categoria a partir de `allowedRoots`, retornar `{ items, skipped }` e reportar diretórios pulados por permissão insuficiente. 
- Adicionei persistência e handlers IPC em `electron/core/ipc.cjs` para `scan-settings:get`, `scan-settings:add-directory`, `scan-settings:remove-directory`, `scan-settings:set-profile` e passei `authorizedDirectories` + `scanProfile` para `scan-all`. 
- Exponho a nova API no preload (`electron/preload.cjs` e `electron/preload.ts`) com métodos `getScanSettings`, `addAuthorizedDirectory`, `removeAuthorizedDirectory` e `setScanProfile` mantendo `contextBridge` isolado. 
- Implementei o fluxo de seleção/remoção de pastas e seleção de perfil no renderer com o novo componente `src/components/ScanScopeSelector.tsx` e integrei no `src/App.tsx` o carregamento das configurações, execução do scan que retorna `items` e `skipped`, e a exibição dos `skipped` no UI. 
- Atualizei os tipos em `src/types.ts` (`ScanProfile`, `ScanResult`, `SkippedScanTarget`, `ScanSettings`) e a documentação em `README.md` sobre privacidade/permissões/escopo. 

### Testing
- Executei a build da parte React com `npm run build:react`, que concluiu com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4152f731c8330a4908d387190162c)