### PR TITLE
chore: strengthen quality gates and IPC smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Check main-process source strategy
         run: npm run check:main-process
 
-      - name: Build Electron main/preload
-        run: npm run build:electron
+      - name: Lint + typecheck + smoke tests
+        run: npm run ci
 
-      - name: Build React renderer
-        run: npm run build:react
+      - name: Build validation (mandatory)
+        run: npm run validate:build

--- a/README.md
+++ b/README.md
@@ -85,3 +85,29 @@ This check validates:
 - Diretórios não analisados por permissão insuficiente são exibidos na interface, em vez de falha silenciosa.
 - A remoção continua usando envio para a Lixeira (`shell.trashItem`) sempre que permitido pelo sistema.
 - O app mantém Node desabilitado no renderer e expõe somente API mínima via `preload`.
+
+## Contribuição (fluxo obrigatório)
+
+1. Crie uma branch a partir da `main` com escopo claro (`feat/...`, `fix/...`, `chore/...`).
+2. Implemente a mudança com testes e documentação atualizada quando houver impacto de produto ou DX.
+3. Rode localmente antes de abrir PR:
+   ```bash
+   npm run lint
+   npm run typecheck
+   npm run test:smoke:ipc
+   npm run build
+   ```
+4. Abra o Pull Request com descrição objetiva, riscos, plano de rollback e evidências (logs/screenshot quando aplicável).
+
+### Critérios de aprovação
+
+Um PR só pode ser aprovado quando todos os itens abaixo estiverem atendidos:
+
+- CI verde em todas as etapas obrigatórias:
+  - `npm run check:main-process`
+  - `npm run ci`
+  - `npm run validate:build` (falha bloqueia merge)
+- Sem regressões de contratos IPC críticos (`scan-all` e `delete-items`) cobertos pelo smoke test.
+- Sem erros de lint e typecheck.
+- Mudanças com impacto funcional acompanhadas de atualização de README/guia operacional.
+- Pelo menos 1 revisão de código aprovada (owner ou mantenedor responsável).

--- a/electron/core/__tests__/ipc-smoke.test.ts
+++ b/electron/core/__tests__/ipc-smoke.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createIpcHandlers, type ScanSettings } from '../ipc-handlers.js'
+
+test('IPC smoke: scan-all envia progresso e retorna itens', async () => {
+  const progressEvents: number[] = []
+  const settings: ScanSettings = {
+    authorizedDirectories: ['/Users/dev'],
+    scanProfile: 'safe'
+  }
+
+  const handlers = createIpcHandlers({
+    getHomePath: () => '/Users/dev',
+    getWindow: () => ({
+      webContents: {
+        send: (_channel, payload) => {
+          progressEvents.push(payload)
+        }
+      }
+    }),
+    loadScanSettings: async () => settings,
+    saveScanSettings: async (next) => next,
+    addAuthorizedDirectory: async () => settings,
+    runScanAllCategories: async ({ onProgress } = {}) => {
+      onProgress?.(0.5)
+      return {
+        items: [{ id: '1', name: 'file', path: '/tmp/file', size: 42, type: 'file', category: 'Cache' }],
+        skipped: []
+      }
+    },
+    trashItem: async () => undefined
+  })
+
+  const result = await handlers.scanAll()
+
+  assert.equal(progressEvents.length, 1)
+  assert.equal(result.items.length, 1)
+  assert.equal(result.items[0]?.path, '/tmp/file')
+})
+
+test('IPC smoke: delete-items contabiliza sucesso e falhas', async () => {
+  const trashCalls: string[] = []
+  const handlers = createIpcHandlers({
+    getHomePath: () => '/Users/dev',
+    getWindow: () => null,
+    loadScanSettings: async () => ({ authorizedDirectories: ['/Users/dev'], scanProfile: 'safe' }),
+    saveScanSettings: async (next) => next,
+    addAuthorizedDirectory: async () => null,
+    trashItem: async (targetPath) => {
+      trashCalls.push(targetPath)
+      if (targetPath.includes('locked')) {
+        throw new Error('blocked')
+      }
+    }
+  })
+
+  const result = await handlers.deleteItems(null, ['/tmp/a', '/tmp/locked', 123])
+
+  assert.deepEqual(trashCalls, ['/tmp/a', '/tmp/locked'])
+  assert.equal(result.deleted, 1)
+  assert.equal(result.failed.length, 1)
+  assert.equal(result.failed[0]?.path, '/tmp/locked')
+})

--- a/electron/core/ipc-handlers.ts
+++ b/electron/core/ipc-handlers.ts
@@ -1,0 +1,99 @@
+import path from 'node:path'
+import { SCAN_PROFILES, scanAllCategories } from './scanners.js'
+
+export type ScanSettings = {
+  authorizedDirectories: string[]
+  scanProfile: keyof typeof SCAN_PROFILES
+}
+
+export const DEFAULT_SETTINGS: ScanSettings = {
+  authorizedDirectories: [],
+  scanProfile: 'safe'
+}
+
+type LoadScanSettings = () => Promise<ScanSettings>
+type SaveScanSettings = (settings: ScanSettings) => Promise<ScanSettings>
+type AddAuthorizedDirectory = () => Promise<ScanSettings | null>
+
+type IpcHandlerDependencies = {
+  getHomePath: () => string
+  getWindow: () => { webContents: { send: (channel: string, payload: number) => void } } | null
+  loadScanSettings: LoadScanSettings
+  saveScanSettings: SaveScanSettings
+  addAuthorizedDirectory: AddAuthorizedDirectory
+  runScanAllCategories?: typeof scanAllCategories
+  trashItem: (targetPath: string) => Promise<void>
+}
+
+export function createIpcHandlers(deps: IpcHandlerDependencies) {
+  const runScan = deps.runScanAllCategories ?? scanAllCategories
+
+  return {
+    scanAll: async () => {
+      const win = deps.getWindow()
+      const settings = await deps.loadScanSettings()
+
+      return runScan({
+        allowedRoots: settings.authorizedDirectories,
+        profile: settings.scanProfile,
+        onProgress: (progress) => {
+          win?.webContents.send('scan-progress', progress)
+        }
+      })
+    },
+
+    getScanSettings: async (): Promise<ScanSettings> => deps.loadScanSettings(),
+
+    addScanDirectory: async (): Promise<ScanSettings | null> => deps.addAuthorizedDirectory(),
+
+    removeScanDirectory: async (_event: unknown, targetPath: unknown): Promise<ScanSettings> => {
+      const settings = await deps.loadScanSettings()
+      if (typeof targetPath !== 'string') return settings
+
+      const normalizedTarget = path.resolve(targetPath)
+      const authorizedDirectories = settings.authorizedDirectories.filter(
+        (entry) => path.resolve(entry) !== normalizedTarget
+      )
+
+      return deps.saveScanSettings({
+        ...settings,
+        authorizedDirectories: authorizedDirectories.length > 0 ? authorizedDirectories : [deps.getHomePath()]
+      })
+    },
+
+    setScanProfile: async (_event: unknown, profile: unknown): Promise<ScanSettings> => {
+      if (typeof profile !== 'string' || !Object.hasOwn(SCAN_PROFILES, profile)) {
+        return deps.loadScanSettings()
+      }
+
+      const settings = await deps.loadScanSettings()
+      return deps.saveScanSettings({
+        ...settings,
+        scanProfile: profile as keyof typeof SCAN_PROFILES
+      })
+    },
+
+    deleteItems: async (_event: unknown, paths: unknown): Promise<{ deleted: number; failed: Array<{ path: string; message: string }> }> => {
+      const safePaths = Array.isArray(paths) ? paths.filter((p): p is string => typeof p === 'string') : []
+      let deleted = 0
+      const failed: Array<{ path: string; message: string }> = []
+
+      for (const targetPath of safePaths) {
+        try {
+          await deps.trashItem(targetPath)
+          deleted++
+        } catch (error) {
+          failed.push({
+            path: targetPath,
+            message:
+              error instanceof Error
+                ? error.message
+                : 'Não foi possível mover para a Lixeira. O sistema bloqueou esta remoção.'
+          })
+        }
+      }
+
+      return { deleted, failed }
+    }
+  }
+}

--- a/electron/core/ipc.ts
+++ b/electron/core/ipc.ts
@@ -1,17 +1,8 @@
 import { ipcMain, shell, dialog, app, BrowserWindow } from 'electron'
 import path from 'node:path'
 import fs from 'node:fs/promises'
-import { SCAN_PROFILES, scanAllCategories } from './scanners.js'
-
-const DEFAULT_SETTINGS = {
-  authorizedDirectories: [app.getPath('home')],
-  scanProfile: 'safe' as const
-}
-
-type ScanSettings = {
-  authorizedDirectories: string[]
-  scanProfile: keyof typeof SCAN_PROFILES
-}
+import { SCAN_PROFILES } from './scanners.js'
+import { createIpcHandlers, DEFAULT_SETTINGS, type ScanSettings } from './ipc-handlers.js'
 
 function getSettingsPath(): string {
   return path.join(app.getPath('userData'), 'scan-settings.json')
@@ -24,7 +15,7 @@ async function loadScanSettings(): Promise<ScanSettings> {
 
     const authorizedDirectories = Array.isArray(parsed.authorizedDirectories)
       ? parsed.authorizedDirectories.filter((entry): entry is string => typeof entry === 'string')
-      : DEFAULT_SETTINGS.authorizedDirectories
+      : [app.getPath('home')]
 
     const scanProfile =
       typeof parsed.scanProfile === 'string' && Object.hasOwn(SCAN_PROFILES, parsed.scanProfile)
@@ -33,7 +24,10 @@ async function loadScanSettings(): Promise<ScanSettings> {
 
     return { authorizedDirectories, scanProfile }
   } catch {
-    return { ...DEFAULT_SETTINGS }
+    return {
+      ...DEFAULT_SETTINGS,
+      authorizedDirectories: [app.getPath('home')]
+    }
   }
 }
 
@@ -62,68 +56,19 @@ async function addAuthorizedDirectory(): Promise<ScanSettings | null> {
 }
 
 export function registerIpcHandlers(getWindow: () => BrowserWindow | null): void {
-  ipcMain.handle('scan-all', async () => {
-    const win = getWindow()
-    const settings = await loadScanSettings()
-
-    return scanAllCategories({
-      allowedRoots: settings.authorizedDirectories,
-      profile: settings.scanProfile,
-      onProgress: (progress) => {
-        if (win) win.webContents.send('scan-progress', progress)
-      }
-    })
+  const handlers = createIpcHandlers({
+    getHomePath: () => app.getPath('home'),
+    getWindow,
+    loadScanSettings,
+    saveScanSettings,
+    addAuthorizedDirectory,
+    trashItem: shell.trashItem
   })
 
-  ipcMain.handle('scan-settings:get', async () => loadScanSettings())
-
-  ipcMain.handle('scan-settings:add-directory', async () => addAuthorizedDirectory())
-
-  ipcMain.handle('scan-settings:remove-directory', async (_event, targetPath: unknown) => {
-    const settings = await loadScanSettings()
-    if (typeof targetPath !== 'string') return settings
-
-    const normalizedTarget = path.resolve(targetPath)
-    const authorizedDirectories = settings.authorizedDirectories.filter((entry) => path.resolve(entry) !== normalizedTarget)
-
-    return saveScanSettings({
-      ...settings,
-      authorizedDirectories: authorizedDirectories.length > 0 ? authorizedDirectories : [app.getPath('home')]
-    })
-  })
-
-  ipcMain.handle('scan-settings:set-profile', async (_event, profile: unknown) => {
-    if (typeof profile !== 'string' || !Object.hasOwn(SCAN_PROFILES, profile)) {
-      return loadScanSettings()
-    }
-
-    const settings = await loadScanSettings()
-    return saveScanSettings({
-      ...settings,
-      scanProfile: profile as keyof typeof SCAN_PROFILES
-    })
-  })
-
-  ipcMain.handle('delete-items', async (_event, paths: unknown) => {
-    const safePaths = Array.isArray(paths) ? paths.filter((p): p is string => typeof p === 'string') : []
-    let deleted = 0
-    const failed: Array<{ path: string; message: string }> = []
-
-    for (const targetPath of safePaths) {
-      try {
-        await shell.trashItem(targetPath)
-        deleted++
-      } catch (error) {
-        failed.push({
-          path: targetPath,
-          message:
-            error instanceof Error
-              ? error.message
-              : 'Não foi possível mover para a Lixeira. O sistema bloqueou esta remoção.'
-        })
-      }
-    }
-
-    return { deleted, failed }
-  })
+  ipcMain.handle('scan-all', handlers.scanAll)
+  ipcMain.handle('scan-settings:get', handlers.getScanSettings)
+  ipcMain.handle('scan-settings:add-directory', handlers.addScanDirectory)
+  ipcMain.handle('scan-settings:remove-directory', handlers.removeScanDirectory)
+  ipcMain.handle('scan-settings:set-profile', handlers.setScanProfile)
+  ipcMain.handle('delete-items', handlers.deleteItems)
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,48 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+
+export default tseslint.config(
+  {
+    ignores: ['dist/**', 'dist-electron/**', 'node_modules/**']
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname
+      },
+      globals: {
+        ...globals.browser
+      }
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': 'warn'
+    }
+  },
+  {
+    files: ['electron/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: ['./electron/tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname
+      },
+      globals: {
+        ...globals.node
+      }
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error'
+    }
+  }
+)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "concurrently -k \"vite\" \"npm:build:electron:watch\" \"wait-on tcp:5173 file:dist-electron/main.js && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 electron .\"",
     "build:react": "vite build",
     "start": "npm run build:electron && electron .",
-    "lint": "echo \"(add your linter here)\"",
+    "lint": "tsc --noEmit -p tsconfig.json",
     "build:all": "npm run build && electron-builder",
     "build:mas": "npm run build && electron-builder --mac mas",
     "build:mas-dev": "npm run build && electron-builder --mac mas-dev",
@@ -18,7 +18,11 @@
     "build:electron": "tsc -p electron/tsconfig.json",
     "build:electron:watch": "tsc -p electron/tsconfig.json --watch --preserveWatchOutput",
     "build": "npm run build:react && npm run build:electron",
-    "check:main-process": "node scripts/check-main-process-single-source.mjs"
+    "check:main-process": "node scripts/check-main-process-single-source.mjs",
+    "typecheck": "tsc --noEmit",
+    "test:smoke:ipc": "npm run build:electron && node --test dist-electron/core/__tests__/ipc-smoke.test.js",
+    "validate:build": "npm run build",
+    "ci": "npm run lint && npm run typecheck && npm run test:smoke:ipc"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",


### PR DESCRIPTION
### Motivation

- Prevent regressions on critical IPC contracts and enforce static checks before merging by adding a minimal smoke test and stronger CI gates. 
- Replace the placeholder lint script with a real TypeScript/React check and make `typecheck` explicit so type errors are caught in CI. 
- Fail CI on build regressions by making a build validation step mandatory. 

### Description

- Add ESLint configuration for `src/` and `electron/` in `eslint.config.mjs` with TypeScript and React rules. 
- Refactor IPC logic into a testable factory `createIpcHandlers` (`electron/core/ipc-handlers.ts`) and keep production registration in `electron/core/ipc.ts`. 
- Add a minimal IPC smoke test covering `scan-all` (progress + items) and `delete-items` (success + failure) at `electron/core/__tests__/ipc-smoke.test.ts`. 
- Update `package.json` scripts to use `tsc --noEmit` for lint/typecheck, add `test:smoke:ipc`, `typecheck`, `validate:build`, and a composite `ci` script; and update GitHub Actions (`.github/workflows/ci.yml`) to run `npm run ci` and a mandatory `npm run validate:build`. 
- Document contribution flow and PR approval criteria in `README.md` to require the new checks and IPC smoke coverage. 

### Testing

- Ran `npm run lint` (uses `tsc --noEmit -p tsconfig.json`) and it succeeded. 
- Ran `npm run typecheck` (`tsc --noEmit`) and it succeeded. 
- Ran the IPC smoke tests via `npm run test:smoke:ipc` and both smoke tests passed. 
- Ran the full composite `npm run ci` and `npm run validate:build` and both completed successfully (renderer build + electron main build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e418138d948330a50cf669450d4b4d)