### PR TITLE
feat: add auditable risk scoring, cleanup presets, reminders and local metrics

### DIFF
--- a/electron/core/__tests__/ipc-smoke.test.ts
+++ b/electron/core/__tests__/ipc-smoke.test.ts
@@ -2,19 +2,39 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { createIpcHandlers, type ScanSettings } from '../ipc-handlers.js'
 
+function buildSettings(): ScanSettings {
+  return {
+    authorizedDirectories: ['/Users/dev'],
+    scanProfile: 'safe',
+    reminder: {
+      frequency: 'off'
+    },
+    metrics: {
+      enabled: false,
+      totals: {
+        scansStarted: 0,
+        scansCompleted: 0,
+        cleanActions: 0,
+        itemsSelected: 0,
+        itemsDeleted: 0
+      },
+      timeline: {}
+    }
+  }
+}
+
 test('IPC smoke: scan-all envia progresso e retorna itens', async () => {
   const progressEvents: number[] = []
-  const settings: ScanSettings = {
-    authorizedDirectories: ['/Users/dev'],
-    scanProfile: 'safe'
-  }
+  const settings = buildSettings()
 
   const handlers = createIpcHandlers({
     getHomePath: () => '/Users/dev',
     getWindow: () => ({
       webContents: {
         send: (_channel, payload) => {
-          progressEvents.push(payload)
+          if (typeof payload === 'number') {
+            progressEvents.push(payload)
+          }
         }
       }
     }),
@@ -24,11 +44,24 @@ test('IPC smoke: scan-all envia progresso e retorna itens', async () => {
     runScanAllCategories: async ({ onProgress } = {}) => {
       onProgress?.(0.5)
       return {
-        items: [{ id: '1', name: 'file', path: '/tmp/file', size: 42, type: 'file', category: 'Cache' }],
+        items: [
+          {
+            id: '1',
+            name: 'file',
+            path: '/tmp/file',
+            size: 42,
+            type: 'file',
+            category: 'Cache',
+            safetyScore: 90,
+            riskLevel: 'low',
+            recommendationReasons: ['test']
+          }
+        ],
         skipped: []
       }
     },
-    trashItem: async () => undefined
+    trashItem: async () => undefined,
+    onSettingsUpdated: () => undefined
   })
 
   const result = await handlers.scanAll()
@@ -43,7 +76,7 @@ test('IPC smoke: delete-items contabiliza sucesso e falhas', async () => {
   const handlers = createIpcHandlers({
     getHomePath: () => '/Users/dev',
     getWindow: () => null,
-    loadScanSettings: async () => ({ authorizedDirectories: ['/Users/dev'], scanProfile: 'safe' }),
+    loadScanSettings: async () => buildSettings(),
     saveScanSettings: async (next) => next,
     addAuthorizedDirectory: async () => null,
     trashItem: async (targetPath) => {
@@ -51,7 +84,8 @@ test('IPC smoke: delete-items contabiliza sucesso e falhas', async () => {
       if (targetPath.includes('locked')) {
         throw new Error('blocked')
       }
-    }
+    },
+    onSettingsUpdated: () => undefined
   })
 
   const result = await handlers.deleteItems(null, ['/tmp/a', '/tmp/locked', 123])

--- a/electron/core/ipc-handlers.ts
+++ b/electron/core/ipc-handlers.ts
@@ -1,14 +1,54 @@
 import path from 'node:path'
 import { SCAN_PROFILES, scanAllCategories } from './scanners.js'
 
+export type ReminderFrequency = 'off' | 'weekly' | 'monthly'
+
+export type LocalMetrics = {
+  enabled: boolean
+  totals: {
+    scansStarted: number
+    scansCompleted: number
+    cleanActions: number
+    itemsSelected: number
+    itemsDeleted: number
+  }
+  timeline: {
+    firstScanAt?: number
+    lastScanAt?: number
+    lastCleanAt?: number
+  }
+}
+
+export type ReminderSettings = {
+  frequency: ReminderFrequency
+  nextReminderAt?: number
+  lastReminderSentAt?: number
+}
+
 export type ScanSettings = {
   authorizedDirectories: string[]
   scanProfile: keyof typeof SCAN_PROFILES
+  reminder: ReminderSettings
+  metrics: LocalMetrics
 }
 
 export const DEFAULT_SETTINGS: ScanSettings = {
   authorizedDirectories: [],
-  scanProfile: 'safe'
+  scanProfile: 'safe',
+  reminder: {
+    frequency: 'off'
+  },
+  metrics: {
+    enabled: false,
+    totals: {
+      scansStarted: 0,
+      scansCompleted: 0,
+      cleanActions: 0,
+      itemsSelected: 0,
+      itemsDeleted: 0
+    },
+    timeline: {}
+  }
 }
 
 type LoadScanSettings = () => Promise<ScanSettings>
@@ -17,12 +57,30 @@ type AddAuthorizedDirectory = () => Promise<ScanSettings | null>
 
 type IpcHandlerDependencies = {
   getHomePath: () => string
-  getWindow: () => { webContents: { send: (channel: string, payload: number) => void } } | null
+  getWindow: () => { webContents: { send: (channel: string, payload: number | { frequency: ReminderFrequency; dueAt: number }) => void } } | null
   loadScanSettings: LoadScanSettings
   saveScanSettings: SaveScanSettings
   addAuthorizedDirectory: AddAuthorizedDirectory
   runScanAllCategories?: typeof scanAllCategories
   trashItem: (targetPath: string) => Promise<void>
+  onSettingsUpdated: (settings: ScanSettings) => void
+}
+
+const REMINDER_INTERVAL_MS: Record<Exclude<ReminderFrequency, 'off'>, number> = {
+  weekly: 7 * 24 * 60 * 60 * 1000,
+  monthly: 30 * 24 * 60 * 60 * 1000
+}
+
+function nextReminderTimestamp(frequency: ReminderFrequency, from = Date.now()): number | undefined {
+  if (frequency === 'off') return undefined
+  return from + REMINDER_INTERVAL_MS[frequency]
+}
+
+function withUpdatedMetricTotals(current: ScanSettings, updater: (metrics: LocalMetrics) => LocalMetrics): ScanSettings {
+  return {
+    ...current,
+    metrics: updater(current.metrics)
+  }
 }
 
 export function createIpcHandlers(deps: IpcHandlerDependencies) {
@@ -32,14 +90,51 @@ export function createIpcHandlers(deps: IpcHandlerDependencies) {
     scanAll: async () => {
       const win = deps.getWindow()
       const settings = await deps.loadScanSettings()
+      const startedAt = Date.now()
 
-      return runScan({
+      if (settings.metrics.enabled) {
+        const updatedStart = withUpdatedMetricTotals(settings, (metrics) => ({
+          ...metrics,
+          totals: {
+            ...metrics.totals,
+            scansStarted: metrics.totals.scansStarted + 1
+          },
+          timeline: {
+            ...metrics.timeline,
+            firstScanAt: metrics.timeline.firstScanAt ?? startedAt,
+            lastScanAt: startedAt
+          }
+        }))
+        await deps.saveScanSettings(updatedStart)
+      }
+
+      const result = await runScan({
         allowedRoots: settings.authorizedDirectories,
         profile: settings.scanProfile,
         onProgress: (progress) => {
           win?.webContents.send('scan-progress', progress)
         }
       })
+
+      const refreshed = await deps.loadScanSettings()
+      if (refreshed.metrics.enabled) {
+        const completedAt = Date.now()
+        const updatedComplete = withUpdatedMetricTotals(refreshed, (metrics) => ({
+          ...metrics,
+          totals: {
+            ...metrics.totals,
+            scansCompleted: metrics.totals.scansCompleted + 1
+          },
+          timeline: {
+            ...metrics.timeline,
+            firstScanAt: metrics.timeline.firstScanAt ?? completedAt,
+            lastScanAt: completedAt
+          }
+        }))
+        await deps.saveScanSettings(updatedComplete)
+      }
+
+      return result
     },
 
     getScanSettings: async (): Promise<ScanSettings> => deps.loadScanSettings(),
@@ -55,10 +150,14 @@ export function createIpcHandlers(deps: IpcHandlerDependencies) {
         (entry) => path.resolve(entry) !== normalizedTarget
       )
 
-      return deps.saveScanSettings({
+      const next = {
         ...settings,
         authorizedDirectories: authorizedDirectories.length > 0 ? authorizedDirectories : [deps.getHomePath()]
-      })
+      }
+
+      const saved = await deps.saveScanSettings(next)
+      deps.onSettingsUpdated(saved)
+      return saved
     },
 
     setScanProfile: async (_event: unknown, profile: unknown): Promise<ScanSettings> => {
@@ -67,10 +166,110 @@ export function createIpcHandlers(deps: IpcHandlerDependencies) {
       }
 
       const settings = await deps.loadScanSettings()
-      return deps.saveScanSettings({
+      const saved = await deps.saveScanSettings({
         ...settings,
         scanProfile: profile as keyof typeof SCAN_PROFILES
       })
+      deps.onSettingsUpdated(saved)
+      return saved
+    },
+
+    setReminderFrequency: async (_event: unknown, frequency: unknown): Promise<ScanSettings> => {
+      if (frequency !== 'off' && frequency !== 'weekly' && frequency !== 'monthly') {
+        return deps.loadScanSettings()
+      }
+
+      const settings = await deps.loadScanSettings()
+      const saved = await deps.saveScanSettings({
+        ...settings,
+        reminder: {
+          frequency,
+          nextReminderAt: nextReminderTimestamp(frequency),
+          lastReminderSentAt: settings.reminder.lastReminderSentAt
+        }
+      })
+      deps.onSettingsUpdated(saved)
+      return saved
+    },
+
+    setMetricsOptIn: async (_event: unknown, enabled: unknown): Promise<ScanSettings> => {
+      if (typeof enabled !== 'boolean') return deps.loadScanSettings()
+
+      const settings = await deps.loadScanSettings()
+      const saved = await deps.saveScanSettings({
+        ...settings,
+        metrics: {
+          ...settings.metrics,
+          enabled
+        }
+      })
+      deps.onSettingsUpdated(saved)
+      return saved
+    },
+
+    trackMetricEvent: async (_event: unknown, eventName: unknown, payload: unknown): Promise<void> => {
+      if (typeof eventName !== 'string') return
+      const settings = await deps.loadScanSettings()
+      if (!settings.metrics.enabled) return
+
+      const safePayload = payload && typeof payload === 'object' ? payload as Record<string, unknown> : {}
+
+      let updated = settings
+      if (eventName === 'selection_changed') {
+        const selectedCount = typeof safePayload.selectedCount === 'number' ? Math.max(0, Math.floor(safePayload.selectedCount)) : 0
+        updated = withUpdatedMetricTotals(updated, (metrics) => ({
+          ...metrics,
+          totals: {
+            ...metrics.totals,
+            itemsSelected: Math.max(metrics.totals.itemsSelected, selectedCount)
+          }
+        }))
+      }
+
+      if (eventName === 'clean_triggered') {
+        const selectedCount = typeof safePayload.selectedCount === 'number' ? Math.max(0, Math.floor(safePayload.selectedCount)) : 0
+        updated = withUpdatedMetricTotals(updated, (metrics) => ({
+          ...metrics,
+          totals: {
+            ...metrics.totals,
+            cleanActions: metrics.totals.cleanActions + 1,
+            itemsSelected: metrics.totals.itemsSelected + selectedCount
+          },
+          timeline: {
+            ...metrics.timeline,
+            lastCleanAt: Date.now()
+          }
+        }))
+      }
+
+      if (eventName === 'clean_completed') {
+        const deletedCount = typeof safePayload.deletedCount === 'number' ? Math.max(0, Math.floor(safePayload.deletedCount)) : 0
+        updated = withUpdatedMetricTotals(updated, (metrics) => ({
+          ...metrics,
+          totals: {
+            ...metrics.totals,
+            itemsDeleted: metrics.totals.itemsDeleted + deletedCount
+          }
+        }))
+      }
+
+      await deps.saveScanSettings(updated)
+    },
+
+    markReminderSent: async (): Promise<void> => {
+      const settings = await deps.loadScanSettings()
+      if (settings.reminder.frequency === 'off') return
+
+      const now = Date.now()
+      const saved = await deps.saveScanSettings({
+        ...settings,
+        reminder: {
+          ...settings.reminder,
+          lastReminderSentAt: now,
+          nextReminderAt: nextReminderTimestamp(settings.reminder.frequency, now)
+        }
+      })
+      deps.onSettingsUpdated(saved)
     },
 
     deleteItems: async (_event: unknown, paths: unknown): Promise<{ deleted: number; failed: Array<{ path: string; message: string }> }> => {

--- a/electron/core/ipc.ts
+++ b/electron/core/ipc.ts
@@ -1,33 +1,68 @@
-import { ipcMain, shell, dialog, app, BrowserWindow } from 'electron'
+import { ipcMain, shell, dialog, app, BrowserWindow, Notification } from 'electron'
 import path from 'node:path'
 import fs from 'node:fs/promises'
 import { SCAN_PROFILES } from './scanners.js'
-import { createIpcHandlers, DEFAULT_SETTINGS, type ScanSettings } from './ipc-handlers.js'
+import { createIpcHandlers, DEFAULT_SETTINGS, type ReminderFrequency, type ScanSettings } from './ipc-handlers.js'
 
 function getSettingsPath(): string {
   return path.join(app.getPath('userData'), 'scan-settings.json')
 }
 
+function normalizeSettings(parsed: unknown): ScanSettings {
+  const candidate = parsed && typeof parsed === 'object' ? parsed as Partial<ScanSettings> : {}
+
+  const authorizedDirectories = Array.isArray(candidate.authorizedDirectories)
+    ? candidate.authorizedDirectories.filter((entry): entry is string => typeof entry === 'string')
+    : [app.getPath('home')]
+
+  const scanProfile =
+    typeof candidate.scanProfile === 'string' && Object.hasOwn(SCAN_PROFILES, candidate.scanProfile)
+      ? (candidate.scanProfile as keyof typeof SCAN_PROFILES)
+      : DEFAULT_SETTINGS.scanProfile
+
+  const reminderFrequency =
+    candidate.reminder?.frequency === 'weekly' || candidate.reminder?.frequency === 'monthly' || candidate.reminder?.frequency === 'off'
+      ? candidate.reminder.frequency
+      : DEFAULT_SETTINGS.reminder.frequency
+
+  const reminder = {
+    frequency: reminderFrequency,
+    nextReminderAt: typeof candidate.reminder?.nextReminderAt === 'number' ? candidate.reminder.nextReminderAt : undefined,
+    lastReminderSentAt:
+      typeof candidate.reminder?.lastReminderSentAt === 'number' ? candidate.reminder.lastReminderSentAt : undefined
+  }
+
+  const metricsEnabled = typeof candidate.metrics?.enabled === 'boolean' ? candidate.metrics.enabled : DEFAULT_SETTINGS.metrics.enabled
+
+  return {
+    authorizedDirectories: authorizedDirectories.length > 0 ? authorizedDirectories : [app.getPath('home')],
+    scanProfile,
+    reminder,
+    metrics: {
+      enabled: metricsEnabled,
+      totals: {
+        scansStarted: candidate.metrics?.totals?.scansStarted ?? 0,
+        scansCompleted: candidate.metrics?.totals?.scansCompleted ?? 0,
+        cleanActions: candidate.metrics?.totals?.cleanActions ?? 0,
+        itemsSelected: candidate.metrics?.totals?.itemsSelected ?? 0,
+        itemsDeleted: candidate.metrics?.totals?.itemsDeleted ?? 0
+      },
+      timeline: {
+        firstScanAt: candidate.metrics?.timeline?.firstScanAt,
+        lastScanAt: candidate.metrics?.timeline?.lastScanAt,
+        lastCleanAt: candidate.metrics?.timeline?.lastCleanAt
+      }
+    }
+  }
+}
+
 async function loadScanSettings(): Promise<ScanSettings> {
   try {
     const raw = await fs.readFile(getSettingsPath(), 'utf-8')
-    const parsed: { authorizedDirectories?: unknown; scanProfile?: unknown } = JSON.parse(raw)
-
-    const authorizedDirectories = Array.isArray(parsed.authorizedDirectories)
-      ? parsed.authorizedDirectories.filter((entry): entry is string => typeof entry === 'string')
-      : [app.getPath('home')]
-
-    const scanProfile =
-      typeof parsed.scanProfile === 'string' && Object.hasOwn(SCAN_PROFILES, parsed.scanProfile)
-        ? (parsed.scanProfile as keyof typeof SCAN_PROFILES)
-        : DEFAULT_SETTINGS.scanProfile
-
-    return { authorizedDirectories, scanProfile }
+    const parsed = JSON.parse(raw)
+    return normalizeSettings(parsed)
   } catch {
-    return {
-      ...DEFAULT_SETTINGS,
-      authorizedDirectories: [app.getPath('home')]
-    }
+    return normalizeSettings(DEFAULT_SETTINGS)
   }
 }
 
@@ -55,6 +90,48 @@ async function addAuthorizedDirectory(): Promise<ScanSettings | null> {
   })
 }
 
+const REMINDER_INTERVAL_MS: Record<Exclude<ReminderFrequency, 'off'>, number> = {
+  weekly: 7 * 24 * 60 * 60 * 1000,
+  monthly: 30 * 24 * 60 * 60 * 1000
+}
+
+function computeNextReminder(frequency: ReminderFrequency, from = Date.now()): number | undefined {
+  if (frequency === 'off') return undefined
+  return from + REMINDER_INTERVAL_MS[frequency]
+}
+
+function formatFrequencyLabel(frequency: ReminderFrequency): string {
+  if (frequency === 'monthly') return 'mensal'
+  if (frequency === 'weekly') return 'semanal'
+  return 'desativado'
+}
+
+let reminderInterval: NodeJS.Timeout | null = null
+
+async function checkAndDispatchReminder(getWindow: () => BrowserWindow | null, handlers: ReturnType<typeof createIpcHandlers>) {
+  const settings = await loadScanSettings()
+  const reminder = settings.reminder
+  if (reminder.frequency === 'off') return
+
+  const now = Date.now()
+  const dueAt = reminder.nextReminderAt ?? computeNextReminder(reminder.frequency, now)
+  if (!dueAt || dueAt > now) return
+
+  const win = getWindow()
+  if (win) {
+    win.webContents.send('scan-reminder', { frequency: reminder.frequency, dueAt })
+  }
+
+  if (Notification.isSupported()) {
+    new Notification({
+      title: 'Lembrete de análise',
+      body: `Hora de executar sua análise ${formatFrequencyLabel(reminder.frequency)} no CleanMyMac Pro.`
+    }).show()
+  }
+
+  await handlers.markReminderSent()
+}
+
 export function registerIpcHandlers(getWindow: () => BrowserWindow | null): void {
   const handlers = createIpcHandlers({
     getHomePath: () => app.getPath('home'),
@@ -62,7 +139,18 @@ export function registerIpcHandlers(getWindow: () => BrowserWindow | null): void
     loadScanSettings,
     saveScanSettings,
     addAuthorizedDirectory,
-    trashItem: shell.trashItem
+    trashItem: shell.trashItem,
+    onSettingsUpdated: (settings) => {
+      if (settings.reminder.frequency !== 'off' && !settings.reminder.nextReminderAt) {
+        void saveScanSettings({
+          ...settings,
+          reminder: {
+            ...settings.reminder,
+            nextReminderAt: computeNextReminder(settings.reminder.frequency)
+          }
+        })
+      }
+    }
   })
 
   ipcMain.handle('scan-all', handlers.scanAll)
@@ -70,5 +158,15 @@ export function registerIpcHandlers(getWindow: () => BrowserWindow | null): void
   ipcMain.handle('scan-settings:add-directory', handlers.addScanDirectory)
   ipcMain.handle('scan-settings:remove-directory', handlers.removeScanDirectory)
   ipcMain.handle('scan-settings:set-profile', handlers.setScanProfile)
+  ipcMain.handle('scan-settings:set-reminder-frequency', handlers.setReminderFrequency)
+  ipcMain.handle('metrics:set-opt-in', handlers.setMetricsOptIn)
+  ipcMain.handle('metrics:track-event', handlers.trackMetricEvent)
   ipcMain.handle('delete-items', handlers.deleteItems)
+
+  if (reminderInterval) clearInterval(reminderInterval)
+  reminderInterval = setInterval(() => {
+    void checkAndDispatchReminder(getWindow, handlers)
+  }, 60 * 1000)
+
+  void checkAndDispatchReminder(getWindow, handlers)
 }

--- a/electron/core/scanners.ts
+++ b/electron/core/scanners.ts
@@ -13,6 +13,8 @@ export const SCAN_PROFILES = {
 type ScanProfile = keyof typeof SCAN_PROFILES
 export type CleanupCategory = (typeof SCAN_PROFILES)[ScanProfile][number]
 
+export type RiskLevel = 'low' | 'medium' | 'high'
+
 interface ScanItem {
   id: string
   name: string
@@ -21,6 +23,9 @@ interface ScanItem {
   type: 'file' | 'directory'
   category: CleanupCategory
   lastModified?: number
+  safetyScore: number
+  riskLevel: RiskLevel
+  recommendationReasons: string[]
 }
 
 interface SkippedDirectory {
@@ -39,6 +44,15 @@ interface ScanAllCategoriesOptions {
   onProgress?: (progress: number) => void
   allowedRoots?: string[]
   profile?: ScanProfile
+}
+
+const CATEGORY_BASE_SCORE: Record<CleanupCategory, number> = {
+  Cache: 88,
+  Logs: 86,
+  Temporary: 80,
+  'Old Downloads': 58,
+  'Browser Cache': 83,
+  'App Support': 42
 }
 
 function normalizePath(targetPath: string): string {
@@ -103,6 +117,74 @@ async function listDirectoryDetailed(dir: string) {
     }
   } catch (error) {
     return { entries: [], error }
+  }
+}
+
+function clampScore(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+function buildSafetyAssessment(item: {
+  category: CleanupCategory
+  type: 'file' | 'directory'
+  size: number
+  lastModified?: number
+}): { safetyScore: number; riskLevel: RiskLevel; recommendationReasons: string[] } {
+  let score = CATEGORY_BASE_SCORE[item.category] ?? 50
+  const reasons: string[] = []
+
+  reasons.push(`Critério auditável: categoria ${item.category} inicia com score base ${score}/100.`)
+
+  if (item.type === 'directory') {
+    score -= 10
+    reasons.push('Diretório completo detectado: remoção impacta múltiplos arquivos (+risco).')
+  } else {
+    score += 4
+    reasons.push('Arquivo individual detectado: reversão e inspeção são mais simples (-risco).')
+  }
+
+  const sizeMb = item.size / (1024 * 1024)
+  if (sizeMb > 1024) {
+    score -= 20
+    reasons.push('Tamanho acima de 1 GB: provável conter dados relevantes (+risco).')
+  } else if (sizeMb > 200) {
+    score -= 12
+    reasons.push('Tamanho entre 200 MB e 1 GB: revisão manual recomendada (+risco moderado).')
+  } else if (sizeMb < 50) {
+    score += 6
+    reasons.push('Item pequeno (<50 MB): impacto potencial reduzido (-risco).')
+  }
+
+  if (item.lastModified) {
+    const ageMs = Date.now() - item.lastModified
+    const ageDays = ageMs / (24 * 60 * 60 * 1000)
+
+    if (ageDays >= 180) {
+      score += 16
+      reasons.push('Sem modificação há 180+ dias: forte sinal de obsolescência (-risco).')
+    } else if (ageDays >= 60) {
+      score += 9
+      reasons.push('Sem modificação há 60+ dias: provável baixa utilidade atual (-risco).')
+    } else if (ageDays <= 7) {
+      score -= 16
+      reasons.push('Modificado nos últimos 7 dias: potencialmente em uso ativo (+risco).')
+    }
+  } else {
+    reasons.push('Sem metadado de modificação: score mantém peso conservador.')
+  }
+
+  const clamped = clampScore(score)
+  let riskLevel: RiskLevel = 'medium'
+
+  if (clamped >= 75) riskLevel = 'low'
+  else if (clamped < 45) riskLevel = 'high'
+
+  reasons.push(`Score final ${clamped}/100 com nível de risco ${riskLevel.toUpperCase()}.`)
+
+  return {
+    safetyScore: clamped,
+    riskLevel,
+    recommendationReasons: reasons
   }
 }
 
@@ -172,6 +254,13 @@ async function scanGroup(
           continue
         }
 
+        const assessment = buildSafetyAssessment({
+          category,
+          type: entry.isDir ? 'directory' : 'file',
+          size,
+          lastModified: st.mtimeMs
+        })
+
         out.push({
           id: uuidv4(),
           name: entry.name,
@@ -179,7 +268,10 @@ async function scanGroup(
           size,
           type: entry.isDir ? 'directory' : 'file',
           category,
-          lastModified: st.mtimeMs
+          lastModified: st.mtimeMs,
+          safetyScore: assessment.safetyScore,
+          riskLevel: assessment.riskLevel,
+          recommendationReasons: assessment.recommendationReasons
         })
 
         processedItems++
@@ -195,7 +287,7 @@ async function scanGroup(
     processedDirs++
   }
 
-  out.sort((a, b) => b.size - a.size)
+  out.sort((a, b) => b.safetyScore - a.safetyScore || b.size - a.size)
   return { items: out, skipped }
 }
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -6,6 +6,9 @@ contextBridge.exposeInMainWorld('cleaner', {
   addAuthorizedDirectory: () => ipcRenderer.invoke('scan-settings:add-directory'),
   removeAuthorizedDirectory: (targetPath: string) => ipcRenderer.invoke('scan-settings:remove-directory', targetPath),
   setScanProfile: (profile: string) => ipcRenderer.invoke('scan-settings:set-profile', profile),
+  setReminderFrequency: (frequency: string) => ipcRenderer.invoke('scan-settings:set-reminder-frequency', frequency),
+  setMetricsOptIn: (enabled: boolean) => ipcRenderer.invoke('metrics:set-opt-in', enabled),
+  trackMetricEvent: (eventName: string, payload?: Record<string, unknown>) => ipcRenderer.invoke('metrics:track-event', eventName, payload),
   deleteItems: (paths: string[]) => ipcRenderer.invoke(
     'delete-items',
     Array.isArray(paths) ? paths.filter((p) => typeof p === 'string') : []
@@ -14,5 +17,10 @@ contextBridge.exposeInMainWorld('cleaner', {
     const handler = (_: unknown, value: number) => cb(value)
     ipcRenderer.on('scan-progress', handler)
     return () => ipcRenderer.removeListener('scan-progress', handler)
+  },
+  onReminder: (cb: (payload: { frequency: 'off' | 'weekly' | 'monthly'; dueAt: number }) => void) => {
+    const handler = (_: unknown, value: { frequency: 'off' | 'weekly' | 'monthly'; dueAt: number }) => cb(value)
+    ipcRenderer.on('scan-reminder', handler)
+    return () => ipcRenderer.removeListener('scan-reminder', handler)
   }
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,35 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { CleanupCategory, CleanupItem, CATEGORY_ORDER, ScanProfile, SkippedScanTarget } from './types'
+import { CleanupCategory, CleanupItem, CATEGORY_ORDER, CleanupPreset, ReminderFrequency, ScanProfile, SkippedScanTarget } from './types'
 import { Header } from './components/Header'
 import { Sidebar } from './components/Sidebar'
 import { CategorySection } from './components/CategorySection'
 import { ScanScopeSelector } from './components/ScanScopeSelector'
 import { formatBytes } from './utils/format'
 import { Search, Loader2, FolderOpen, ShieldAlert } from 'lucide-react'
+
+const CLEANUP_PRESETS: Array<{ id: CleanupPreset; label: string; description: string }> = [
+  {
+    id: 'conservative',
+    label: 'Conservador',
+    description: 'Seleciona apenas risco baixo (score >= 75).'
+  },
+  {
+    id: 'balanced',
+    label: 'Balanceado',
+    description: 'Seleciona risco baixo e médio seguro (score >= 55).'
+  },
+  {
+    id: 'aggressive',
+    label: 'Agressivo',
+    description: 'Seleciona tudo, exceto risco alto com score < 25.'
+  }
+]
+
+function shouldSelectByPreset(item: CleanupItem, preset: CleanupPreset): boolean {
+  if (preset === 'conservative') return item.riskLevel === 'low' && item.safetyScore >= 75
+  if (preset === 'balanced') return item.riskLevel !== 'high' && item.safetyScore >= 55
+  return !(item.riskLevel === 'high' && item.safetyScore < 25)
+}
 
 export default function App() {
   const [items, setItems] = useState<CleanupItem[]>([])
@@ -17,10 +41,22 @@ export default function App() {
   const [scanProfile, setScanProfile] = useState<ScanProfile>('safe')
   const [authorizedDirectories, setAuthorizedDirectories] = useState<string[]>([])
   const [skippedTargets, setSkippedTargets] = useState<SkippedScanTarget[]>([])
+  const [activePreset, setActivePreset] = useState<CleanupPreset | null>(null)
+  const [reminderFrequency, setReminderFrequency] = useState<ReminderFrequency>('off')
+  const [metricsEnabled, setMetricsEnabled] = useState(false)
 
   useEffect(() => {
     if (!window.cleaner) return
     const off = window.cleaner.onScanProgress((p) => setProgress(p))
+    return () => off && off()
+  }, [])
+
+  useEffect(() => {
+    if (!window.cleaner) return
+    const off = window.cleaner.onReminder((payload) => {
+      const dueDate = new Date(payload.dueAt).toLocaleDateString('pt-BR')
+      alert(`Lembrete local: sua análise ${payload.frequency === 'weekly' ? 'semanal' : 'mensal'} está pendente desde ${dueDate}.`)
+    })
     return () => off && off()
   }, [])
 
@@ -30,9 +66,11 @@ export default function App() {
       const settings = await window.cleaner.getScanSettings()
       setScanProfile(settings.scanProfile)
       setAuthorizedDirectories(settings.authorizedDirectories)
+      setReminderFrequency(settings.reminder.frequency)
+      setMetricsEnabled(settings.metrics.enabled)
     }
 
-    loadSettings()
+    void loadSettings()
   }, [])
 
   const totalSize = useMemo(() => items.reduce((acc, it) => acc + it.size, 0), [items])
@@ -47,6 +85,11 @@ export default function App() {
     return g
   }, [items])
 
+  useEffect(() => {
+    if (!window.cleaner || !metricsEnabled) return
+    void window.cleaner.trackMetricEvent('selection_changed', { selectedCount: selectedList.length })
+  }, [selectedList.length, metricsEnabled])
+
   async function handleScan() {
     if (!window.cleaner) return
     setIsScanning(true)
@@ -54,6 +97,7 @@ export default function App() {
     setSelected({})
     setProgress(0)
     setSkippedTargets([])
+    setActivePreset(null)
     const result = await window.cleaner.scanAll()
     setItems(result.items)
     setSkippedTargets(result.skipped)
@@ -66,6 +110,18 @@ export default function App() {
     const settings = await window.cleaner.setScanProfile(profile)
     setScanProfile(settings.scanProfile)
     setAuthorizedDirectories(settings.authorizedDirectories)
+  }
+
+  async function handleReminderChange(frequency: ReminderFrequency) {
+    if (!window.cleaner) return
+    const settings = await window.cleaner.setReminderFrequency(frequency)
+    setReminderFrequency(settings.reminder.frequency)
+  }
+
+  async function handleMetricsOptIn(enabled: boolean) {
+    if (!window.cleaner) return
+    const settings = await window.cleaner.setMetricsOptIn(enabled)
+    setMetricsEnabled(settings.metrics.enabled)
   }
 
   async function handleAddDirectory() {
@@ -83,12 +139,39 @@ export default function App() {
     setAuthorizedDirectories(settings.authorizedDirectories)
   }
 
+  function applyCleanupPreset(preset: CleanupPreset) {
+    const next: Record<string, boolean> = {}
+    for (const item of items) {
+      if (shouldSelectByPreset(item, preset)) {
+        next[item.id] = true
+      }
+    }
+    setSelected(next)
+    setActivePreset(preset)
+  }
+
   async function handleDelete() {
     if (!window.cleaner) return
     if (selectedList.length === 0) return
     const ok = confirm(`Tem certeza que deseja deletar ${selectedList.length} itens?\n\nEspaço a ser liberado: ${formatBytes(selectedSize)}`)
     if (!ok) return
+
+    if (metricsEnabled) {
+      await window.cleaner.trackMetricEvent('clean_triggered', {
+        selectedCount: selectedList.length,
+        selectedSize
+      })
+    }
+
     const { deleted, failed } = await window.cleaner.deleteItems(selectedList.map(i => i.path))
+
+    if (metricsEnabled) {
+      await window.cleaner.trackMetricEvent('clean_completed', {
+        deletedCount: deleted,
+        failedCount: failed.length
+      })
+    }
+
     if (failed.length > 0) {
       const details = failed
         .slice(0, 3)
@@ -106,6 +189,7 @@ export default function App() {
     const kept = items.filter(i => !selected[i.id])
     setItems(kept)
     setSelected({})
+    setActivePreset(null)
   }
 
   function toggle(id: string) {
@@ -119,6 +203,7 @@ export default function App() {
       for (const it of citems) next[it.id] = true
       return next
     })
+    setActivePreset(null)
   }
 
   function deselectAll(category: CleanupCategory) {
@@ -128,6 +213,7 @@ export default function App() {
       for (const it of citems) delete next[it.id]
       return next
     })
+    setActivePreset(null)
   }
 
   return (
@@ -172,11 +258,41 @@ export default function App() {
           <ScanScopeSelector
             profile={scanProfile}
             directories={authorizedDirectories}
+            reminderFrequency={reminderFrequency}
+            metricsEnabled={metricsEnabled}
             onProfileChange={handleProfileChange}
             onAddDirectory={handleAddDirectory}
             onRemoveDirectory={handleRemoveDirectory}
+            onReminderFrequencyChange={handleReminderChange}
+            onMetricsOptInChange={handleMetricsOptIn}
             disabled={isScanning}
           />
+
+          {items.length > 0 && (
+            <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-3 mb-4">
+              <div className="text-xs font-semibold text-gray-500 dark:text-gray-300 mb-2">Presets de limpeza rápida</div>
+              <div className="flex flex-wrap gap-2">
+                {CLEANUP_PRESETS.map((preset) => (
+                  <button
+                    key={preset.id}
+                    onClick={() => applyCleanupPreset(preset.id)}
+                    className={`text-xs sm:text-sm px-3 py-1.5 rounded-lg border transition-colors ${activePreset === preset.id
+                      ? 'bg-blue-500 text-white border-blue-500'
+                      : 'bg-gray-50 dark:bg-gray-900 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700'
+                    }`}
+                    title={preset.description}
+                  >
+                    {preset.label}
+                  </button>
+                ))}
+              </div>
+              {activePreset && (
+                <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-2">
+                  Preset aplicado: {CLEANUP_PRESETS.find((p) => p.id === activePreset)?.description}
+                </p>
+              )}
+            </div>
+          )}
 
           {skippedTargets.length > 0 && !isScanning && (
             <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-xl p-4 mb-4">
@@ -246,11 +362,9 @@ export default function App() {
                   <div className="space-y-3 max-w-md">
                     <h3 className="text-xl sm:text-2xl font-semibold text-gray-800 dark:text-gray-200">Selecione uma categoria</h3>
                     <p className="text-gray-500 dark:text-gray-400 text-base sm:text-lg leading-relaxed">
-                      {sidebarOpen ? (
-                        'Clique em uma categoria na sidebar para visualizar os arquivos encontrados e gerenciar sua limpeza'
-                      ) : (
-                        'Abra a sidebar para selecionar uma categoria e visualizar os arquivos encontrados'
-                      )}
+                      {sidebarOpen
+                        ? 'Clique em uma categoria na sidebar para visualizar os arquivos encontrados e gerenciar sua limpeza'
+                        : 'Abra a sidebar para selecionar uma categoria e visualizar os arquivos encontrados'}
                     </p>
                   </div>
                 </div>

--- a/src/components/CategorySection.tsx
+++ b/src/components/CategorySection.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { CleanupCategory, CleanupItem, CATEGORY_INFO } from '../types'
 import { ItemRow } from './ItemRow'
-import { FolderOpen, Info, CheckSquare, Square } from 'lucide-react'
+import { FolderOpen, Info, CheckSquare, Square, ShieldAlert, ShieldCheck, ShieldQuestion } from 'lucide-react'
 import { formatBytes } from '../utils/format'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip'
 
@@ -14,7 +14,7 @@ export function CategorySection({ category, items, selected, toggle, selectAll, 
   deselectAll?: (category: CleanupCategory) => void
 }) {
   const categoryInfo = CATEGORY_INFO[category]
-  
+
   if (!items || items.length === 0) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8 text-center">
@@ -30,15 +30,22 @@ export function CategorySection({ category, items, selected, toggle, selectAll, 
       </div>
     )
   }
-  
+
   const selectedCount = items.filter(item => selected[item.id]).length
   const totalSize = items.reduce((acc, item) => acc + item.size, 0)
   const selectedSize = items.filter(item => selected[item.id]).reduce((acc, item) => acc + item.size, 0)
-  
+  const avgSafety = Math.round(items.reduce((acc, item) => acc + item.safetyScore, 0) / items.length)
+  const riskCounts = items.reduce(
+    (acc, item) => {
+      acc[item.riskLevel] += 1
+      return acc
+    },
+    { low: 0, medium: 0, high: 0 }
+  )
+
   return (
     <TooltipProvider>
       <div className="space-y-4 sm:space-y-6 flex-1 flex flex-col h-0">
-        {/* Header da Categoria */}
         <div className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-xl sm:rounded-2xl p-4 sm:p-6 border border-blue-200 dark:border-blue-700">
           <div className="flex flex-col space-y-4 lg:flex-row lg:items-center lg:justify-between lg:space-y-0">
             <div className="flex items-center space-x-3 sm:space-x-4">
@@ -59,7 +66,7 @@ export function CategorySection({ category, items, selected, toggle, selectAll, 
                     </TooltipContent>
                   </Tooltip>
                 </div>
-                <div className="grid grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 text-sm">
+                <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6 text-sm">
                   <div className="space-y-1">
                     <p className="text-gray-500 dark:text-gray-400 font-medium text-xs sm:text-sm">Total de Itens</p>
                     <p className="text-base sm:text-lg font-semibold text-gray-900 dark:text-gray-100">{items.length}</p>
@@ -67,6 +74,10 @@ export function CategorySection({ category, items, selected, toggle, selectAll, 
                   <div className="space-y-1">
                     <p className="text-gray-500 dark:text-gray-400 font-medium text-xs sm:text-sm">Tamanho Total</p>
                     <p className="text-base sm:text-lg font-semibold text-gray-900 dark:text-gray-100">{formatBytes(totalSize)}</p>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-gray-500 dark:text-gray-400 font-medium text-xs sm:text-sm">Score Médio</p>
+                    <p className="text-base sm:text-lg font-semibold text-gray-900 dark:text-gray-100">{avgSafety}/100</p>
                   </div>
                   {selectedCount > 0 && (
                     <div className="space-y-1 col-span-2 lg:col-span-1">
@@ -77,10 +88,20 @@ export function CategorySection({ category, items, selected, toggle, selectAll, 
                     </div>
                   )}
                 </div>
+                <div className="flex flex-wrap gap-2 mt-3 text-xs">
+                  <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 font-medium">
+                    <ShieldCheck className="w-3 h-3" /> Baixo: {riskCounts.low}
+                  </span>
+                  <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 font-medium">
+                    <ShieldQuestion className="w-3 h-3" /> Médio: {riskCounts.medium}
+                  </span>
+                  <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-rose-100 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300 font-medium">
+                    <ShieldAlert className="w-3 h-3" /> Alto: {riskCounts.high}
+                  </span>
+                </div>
               </div>
             </div>
-            
-            {/* Ações */}
+
             {(selectAll || deselectAll) && (
               <div className="flex items-center space-x-2 sm:space-x-3 flex-wrap">
                 {selectedCount < items.length && selectAll && (
@@ -100,7 +121,7 @@ export function CategorySection({ category, items, selected, toggle, selectAll, 
                     </TooltipContent>
                   </Tooltip>
                 )}
-                
+
                 {selectedCount > 0 && deselectAll && (
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -122,8 +143,7 @@ export function CategorySection({ category, items, selected, toggle, selectAll, 
             )}
           </div>
         </div>
-        
-        {/* Lista de Arquivos */}
+
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 flex-1 flex flex-col h-0">
           <div className="p-3 sm:p-4 border-b border-gray-100 dark:border-gray-700 flex-shrink-0">
             <h2 className="text-base sm:text-lg font-semibold text-gray-900 dark:text-gray-100">Arquivos Encontrados</h2>
@@ -140,5 +160,3 @@ export function CategorySection({ category, items, selected, toggle, selectAll, 
     </TooltipProvider>
   )
 }
-
-

--- a/src/components/ItemRow.tsx
+++ b/src/components/ItemRow.tsx
@@ -1,83 +1,119 @@
 import React from 'react'
-import { CleanupItem } from '../types'
+import { CleanupItem, RiskLevel } from '../types'
 import { formatBytes } from '../utils/format'
-import { Folder, File, Calendar, Check } from 'lucide-react'
+import { Folder, File, Calendar, Check, ShieldAlert, ShieldCheck, ShieldQuestion } from 'lucide-react'
 
-export function ItemRow({ item, selected, toggle }: { 
-  item: CleanupItem, 
-  selected: boolean, 
-  toggle: (id: string) => void 
+const RISK_UI: Record<RiskLevel, { label: string; className: string; icon: React.ReactNode }> = {
+  low: {
+    label: 'Risco Baixo',
+    className: 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300',
+    icon: <ShieldCheck className="w-3 h-3" />
+  },
+  medium: {
+    label: 'Risco Médio',
+    className: 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300',
+    icon: <ShieldQuestion className="w-3 h-3" />
+  },
+  high: {
+    label: 'Risco Alto',
+    className: 'bg-rose-100 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300',
+    icon: <ShieldAlert className="w-3 h-3" />
+  }
+}
+
+export function ItemRow({ item, selected, toggle }: {
+  item: CleanupItem,
+  selected: boolean,
+  toggle: (id: string) => void
 }) {
+  const riskUi = RISK_UI[item.riskLevel]
+
   return (
-    <div 
-      className={`group flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-4 p-3 sm:p-4 rounded-lg cursor-pointer transition-all duration-150 hover:bg-blue-50 dark:hover:bg-blue-900/20 ${
+    <div
+      className={`group flex flex-col gap-3 sm:gap-4 p-3 sm:p-4 rounded-lg cursor-pointer transition-all duration-150 hover:bg-blue-50 dark:hover:bg-blue-900/20 ${
         selected ? 'bg-blue-50 dark:bg-blue-900/20 ring-1 ring-blue-200 dark:ring-blue-700' : 'bg-white dark:bg-gray-800 hover:shadow-sm'
       }`}
       onClick={() => toggle(item.id)}
     >
-      <div className="flex items-center gap-3 sm:gap-4 w-full sm:flex-1">
-        <div className={`flex-shrink-0 w-5 h-5 sm:w-6 sm:h-6 rounded border-2 flex items-center justify-center transition-all ${
-          selected 
-            ? 'bg-blue-500 dark:bg-blue-600 border-blue-500 dark:border-blue-600' 
-            : 'border-gray-300 dark:border-gray-600 group-hover:border-blue-400 dark:group-hover:border-blue-500 bg-white dark:bg-gray-700'
-        }`}>
-          {selected && <Check className="w-3 h-3 text-white" />}
-        </div>
-        
-        <div className="flex-shrink-0">
-          <div className={`w-8 h-8 sm:w-10 sm:h-10 rounded-lg flex items-center justify-center ${
-            item.type === 'directory' ? 'bg-blue-100 dark:bg-blue-900' : 'bg-gray-100 dark:bg-gray-700'
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-4">
+        <div className="flex items-center gap-3 sm:gap-4 w-full sm:flex-1">
+          <div className={`flex-shrink-0 w-5 h-5 sm:w-6 sm:h-6 rounded border-2 flex items-center justify-center transition-all ${
+            selected
+              ? 'bg-blue-500 dark:bg-blue-600 border-blue-500 dark:border-blue-600'
+              : 'border-gray-300 dark:border-gray-600 group-hover:border-blue-400 dark:group-hover:border-blue-500 bg-white dark:bg-gray-700'
           }`}>
-            {item.type === 'directory' ? (
-              <Folder className="w-4 h-4 sm:w-5 sm:h-5 text-blue-600 dark:text-blue-400" />
-            ) : (
-              <File className="w-4 h-4 sm:w-5 sm:h-5 text-gray-600 dark:text-gray-300" />
+            {selected && <Check className="w-3 h-3 text-white" />}
+          </div>
+
+          <div className="flex-shrink-0">
+            <div className={`w-8 h-8 sm:w-10 sm:h-10 rounded-lg flex items-center justify-center ${
+              item.type === 'directory' ? 'bg-blue-100 dark:bg-blue-900' : 'bg-gray-100 dark:bg-gray-700'
+            }`}>
+              {item.type === 'directory' ? (
+                <Folder className="w-4 h-4 sm:w-5 sm:h-5 text-blue-600 dark:text-blue-400" />
+              ) : (
+                <File className="w-4 h-4 sm:w-5 sm:h-5 text-gray-600 dark:text-gray-300" />
+              )}
+            </div>
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <div className="font-medium text-sm sm:text-base text-gray-900 dark:text-gray-100 truncate">{item.name}</div>
+            <div className="text-xs sm:text-sm text-gray-500 dark:text-gray-400 truncate">{item.path}</div>
+            {item.lastModified && (
+              <div className="flex items-center space-x-1 text-xs text-gray-400 dark:text-gray-500 mt-1 sm:hidden">
+                <Calendar className="w-3 h-3" />
+                <span>Modificado: {new Date(item.lastModified).toLocaleDateString('pt-BR')}</span>
+              </div>
             )}
           </div>
         </div>
-        
-        <div className="flex-1 min-w-0">
-          <div className="font-medium text-sm sm:text-base text-gray-900 dark:text-gray-100 truncate">{item.name}</div>
-          <div className="text-xs sm:text-sm text-gray-500 dark:text-gray-400 truncate">{item.path}</div>
-          {item.lastModified && (
-            <div className="flex items-center space-x-1 text-xs text-gray-400 dark:text-gray-500 mt-1 sm:hidden">
-              <Calendar className="w-3 h-3" />
-              <span>Modificado: {new Date(item.lastModified).toLocaleDateString('pt-BR')}</span>
+
+        <div className="flex items-center justify-between w-full sm:w-auto sm:flex-shrink-0 sm:text-right gap-2">
+          <div className="sm:hidden">
+            <div className={`text-xs px-2 py-1 rounded-full inline-block ${
+              item.type === 'directory'
+                ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300'
+                : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
+            }`}>
+              {item.type === 'directory' ? 'Pasta' : 'Arquivo'}
             </div>
-          )}
-        </div>
-      </div>
-      
-      <div className="flex items-center justify-between w-full sm:w-auto sm:flex-shrink-0 sm:text-right">
-        <div className="sm:hidden">
-          <div className={`text-xs px-2 py-1 rounded-full inline-block ${
-            item.type === 'directory' 
-              ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300' 
-              : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
-          }`}>
-            {item.type === 'directory' ? 'Pasta' : 'Arquivo'}
+          </div>
+
+          <div className="text-right">
+            <div className="font-semibold text-sm sm:text-base text-gray-900 dark:text-gray-100">{formatBytes(item.size)}</div>
+            <div className={`hidden sm:block text-xs mt-1 px-3 py-1 rounded-full w-16 text-center ${
+              item.type === 'directory'
+                ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300'
+                : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
+            }`}>
+              {item.type === 'directory' ? 'Pasta' : 'Arquivo'}
+            </div>
+            {item.lastModified && (
+              <div className="hidden sm:flex items-center justify-end space-x-1 text-xs text-gray-400 dark:text-gray-500 mt-1">
+                <Calendar className="w-3 h-3" />
+                <span>Modificado: {new Date(item.lastModified).toLocaleDateString('pt-BR')}</span>
+              </div>
+            )}
           </div>
         </div>
-        
-        <div className="text-right">
-          <div className="font-semibold text-sm sm:text-base text-gray-900 dark:text-gray-100">{formatBytes(item.size)}</div>
-          <div className={`hidden sm:block text-xs mt-1 px-3 py-1 rounded-full w-16 text-center ${
-            item.type === 'directory' 
-              ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300' 
-              : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
-          }`}>
-            {item.type === 'directory' ? 'Pasta' : 'Arquivo'}
-          </div>
-          {item.lastModified && (
-            <div className="hidden sm:flex items-center justify-end space-x-1 text-xs text-gray-400 dark:text-gray-500 mt-1">
-              <Calendar className="w-3 h-3" />
-              <span>Modificado: {new Date(item.lastModified).toLocaleDateString('pt-BR')}</span>
-            </div>
-          )}
-        </div>
       </div>
+
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <span className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full font-medium ${riskUi.className}`}>
+          {riskUi.icon}
+          {riskUi.label}
+        </span>
+        <span className="inline-flex items-center px-2.5 py-1 rounded-full font-medium bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200">
+          Score de segurança: {item.safetyScore}/100
+        </span>
+      </div>
+
+      <ul className="space-y-1 text-xs text-gray-600 dark:text-gray-300 pl-1">
+        {item.recommendationReasons.slice(0, 3).map((reason, index) => (
+          <li key={`${item.id}-reason-${index}`} className="leading-relaxed">• {reason}</li>
+        ))}
+      </ul>
     </div>
   )
 }
-
-

--- a/src/components/ScanScopeSelector.tsx
+++ b/src/components/ScanScopeSelector.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { ScanProfile } from '../types'
-import { Shield, FolderPlus, Trash2 } from 'lucide-react'
+import { ReminderFrequency, ScanProfile } from '../types'
+import { Shield, FolderPlus, Trash2, CalendarClock, BarChart3 } from 'lucide-react'
 
 const PROFILE_OPTIONS: { value: ScanProfile, label: string, description: string }[] = [
   { value: 'quick', label: 'Rápido', description: 'Menos categorias e menor superfície de leitura.' },
@@ -8,19 +8,33 @@ const PROFILE_OPTIONS: { value: ScanProfile, label: string, description: string 
   { value: 'complete', label: 'Completo', description: 'Mais categorias, pode exigir permissões adicionais.' }
 ]
 
+const REMINDER_OPTIONS: { value: ReminderFrequency; label: string }[] = [
+  { value: 'off', label: 'Desativado' },
+  { value: 'weekly', label: 'Semanal' },
+  { value: 'monthly', label: 'Mensal' }
+]
+
 export function ScanScopeSelector({
   profile,
   directories,
+  reminderFrequency,
+  metricsEnabled,
   onProfileChange,
   onAddDirectory,
   onRemoveDirectory,
+  onReminderFrequencyChange,
+  onMetricsOptInChange,
   disabled
 }: {
   profile: ScanProfile
   directories: string[]
+  reminderFrequency: ReminderFrequency
+  metricsEnabled: boolean
   onProfileChange: (profile: ScanProfile) => void
   onAddDirectory: () => void
   onRemoveDirectory: (targetPath: string) => void
+  onReminderFrequencyChange: (frequency: ReminderFrequency) => void
+  onMetricsOptInChange: (enabled: boolean) => void
   disabled?: boolean
 }) {
   return (
@@ -72,6 +86,45 @@ export function ScanScopeSelector({
               </button>
             </div>
           ))}
+        </div>
+      </div>
+
+      <div className="grid md:grid-cols-2 gap-4 pt-2 border-t border-gray-100 dark:border-gray-700">
+        <div>
+          <label className="text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-1">
+            <CalendarClock className="w-3 h-3" />
+            Agendamento de análise
+          </label>
+          <select
+            value={reminderFrequency}
+            disabled={disabled}
+            onChange={(event) => onReminderFrequencyChange(event.target.value as ReminderFrequency)}
+            className="mt-1 w-full bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-lg p-2 text-sm"
+          >
+            {REMINDER_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-1 mb-1">
+            <BarChart3 className="w-3 h-3" />
+            Métricas locais anônimas
+          </label>
+          <button
+            disabled={disabled}
+            onClick={() => onMetricsOptInChange(!metricsEnabled)}
+            className={`w-full text-left px-3 py-2 rounded-lg border text-sm transition-colors ${metricsEnabled
+              ? 'bg-emerald-50 dark:bg-emerald-900/20 border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-300'
+              : 'bg-gray-50 dark:bg-gray-900 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200'
+            }`}
+          >
+            {metricsEnabled ? 'Ativado (opt-in)' : 'Desativado'}
+          </button>
+          <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-1">
+            Guarda apenas contadores locais (scans, seleção, limpeza). Nenhum envio externo.
+          </p>
         </div>
       </div>
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
 export type ItemType = 'file' | 'directory'
 export type CleanupCategory = 'Cache' | 'Logs' | 'Temporary' | 'Old Downloads' | 'Browser Cache' | 'App Support'
 export type ScanProfile = 'quick' | 'safe' | 'complete'
+export type RiskLevel = 'low' | 'medium' | 'high'
+export type CleanupPreset = 'conservative' | 'balanced' | 'aggressive'
+export type ReminderFrequency = 'off' | 'weekly' | 'monthly'
 
 export interface CategoryInfo {
   id: CleanupCategory
@@ -16,6 +19,9 @@ export interface CleanupItem {
   type: ItemType
   category: CleanupCategory
   lastModified?: number
+  safetyScore: number
+  riskLevel: RiskLevel
+  recommendationReasons: string[]
 }
 
 export interface SkippedScanTarget {
@@ -29,9 +35,33 @@ export interface ScanResult {
   skipped: SkippedScanTarget[]
 }
 
+export interface LocalMetricsSettings {
+  enabled: boolean
+  totals: {
+    scansStarted: number
+    scansCompleted: number
+    cleanActions: number
+    itemsSelected: number
+    itemsDeleted: number
+  }
+  timeline: {
+    firstScanAt?: number
+    lastScanAt?: number
+    lastCleanAt?: number
+  }
+}
+
+export interface ReminderSettings {
+  frequency: ReminderFrequency
+  nextReminderAt?: number
+  lastReminderSentAt?: number
+}
+
 export interface ScanSettings {
   authorizedDirectories: string[]
   scanProfile: ScanProfile
+  reminder: ReminderSettings
+  metrics: LocalMetricsSettings
 }
 
 declare global {
@@ -42,8 +72,12 @@ declare global {
       addAuthorizedDirectory: () => Promise<ScanSettings | null>
       removeAuthorizedDirectory: (path: string) => Promise<ScanSettings>
       setScanProfile: (profile: ScanProfile) => Promise<ScanSettings>
+      setReminderFrequency: (frequency: ReminderFrequency) => Promise<ScanSettings>
+      setMetricsOptIn: (enabled: boolean) => Promise<ScanSettings>
+      trackMetricEvent: (eventName: string, payload?: Record<string, unknown>) => Promise<void>
       deleteItems: (paths: string[]) => Promise<{ deleted: number, failed: { path: string, message: string }[] }>
       onScanProgress: (cb: (progress: number) => void) => () => void
+      onReminder: (cb: (payload: { frequency: ReminderFrequency; dueAt: number }) => void) => () => void
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Provide an auditable, explainable assessment for each found item so users can decide what to delete with clear reasons and numeric safety score.
- Surface safety and risk information in the UI and enable quick cleanup presets to speed the clean flow while reducing accidental removal.
- Add local scheduling/reminders and local anonymous metrics (opt-in) to measure and improve conversion and retention signals without external telemetry.

### Description
- Implemented an audit-able safety assessment in the scanner: each item now includes `safetyScore` (0–100), `riskLevel` and `recommendationReasons`, and results are sorted by safety first (`electron/core/scanners.ts`).
- Updated shared types and IPC contract to persist new settings and expose new APIs: `setReminderFrequency`, `setMetricsOptIn`, `trackMetricEvent`, and `onReminder` via the preload layer (`src/types.ts`, `electron/preload.ts`, `electron/core/ipc-handlers.ts`, `electron/core/ipc.ts`).
- UI changes to show risk badge, numeric score and top recommendation reasons per item and a category risk summary, plus quick cleanup presets (Conservador/Balanceado/Agressivo) that select items according to score/risk (`src/components/ItemRow.tsx`, `src/components/CategorySection.tsx`, `src/App.tsx`).
- Scan scheduling and local reminders implemented in the main process with persisted `reminder` settings and a periodic dispatcher that sends `scan-reminder` events and shows an OS `Notification` (`electron/core/ipc.ts`, `electron/core/ipc-handlers.ts`).
- Local anonymous metrics (opt-in) stored in settings and updated by IPC handlers to track `scansStarted`, `scansCompleted`, `cleanActions`, `itemsSelected`, `itemsDeleted` and timeline fields; renderer triggers metric events for selection/clean flows (`electron/core/ipc-handlers.ts`, `src/components/ScanScopeSelector.tsx`, `src/App.tsx`).
- Updated IPC smoke test to reflect expanded settings schema and enriched item payloads (`electron/core/__tests__/ipc-smoke.test.ts`).

### Testing
- Ran `npm run typecheck` (TypeScript `tsc --noEmit`) with no errors.
- Ran `npm run test:smoke:ipc` and the IPC smoke tests passed (all subtests OK).
- Built the app with `npm run build` which completed successfully (frontend build + electron compilation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e419a686a08330b3fec74d7efcce9d)