### PR TITLE
Add cleanup insights: persist bytes/history metrics, expose API and UI panel

### DIFF
--- a/electron/core/__tests__/ipc-smoke.test.ts
+++ b/electron/core/__tests__/ipc-smoke.test.ts
@@ -16,9 +16,11 @@ function buildSettings(): ScanSettings {
         scansCompleted: 0,
         cleanActions: 0,
         itemsSelected: 0,
-        itemsDeleted: 0
+        itemsDeleted: 0,
+        bytesDeleted: 0
       },
-      timeline: {}
+      timeline: {},
+      history: []
     }
   }
 }

--- a/electron/core/ipc-handlers.ts
+++ b/electron/core/ipc-handlers.ts
@@ -11,12 +11,20 @@ export type LocalMetrics = {
     cleanActions: number
     itemsSelected: number
     itemsDeleted: number
+    bytesDeleted: number
   }
   timeline: {
     firstScanAt?: number
     lastScanAt?: number
     lastCleanAt?: number
   }
+  history: Array<{
+    at: number
+    deletedCount: number
+    failedCount: number
+    deletedBytes: number
+    deletedByCategory: Partial<Record<(typeof SCAN_PROFILES)[keyof typeof SCAN_PROFILES][number], number>>
+  }>
 }
 
 export type ReminderSettings = {
@@ -45,9 +53,11 @@ export const DEFAULT_SETTINGS: ScanSettings = {
       scansCompleted: 0,
       cleanActions: 0,
       itemsSelected: 0,
-      itemsDeleted: 0
+      itemsDeleted: 0,
+      bytesDeleted: 0
     },
-    timeline: {}
+    timeline: {},
+    history: []
   }
 }
 
@@ -244,16 +254,50 @@ export function createIpcHandlers(deps: IpcHandlerDependencies) {
 
       if (eventName === 'clean_completed') {
         const deletedCount = typeof safePayload.deletedCount === 'number' ? Math.max(0, Math.floor(safePayload.deletedCount)) : 0
+        const failedCount = typeof safePayload.failedCount === 'number' ? Math.max(0, Math.floor(safePayload.failedCount)) : 0
+        const deletedBytes = typeof safePayload.deletedBytes === 'number' ? Math.max(0, Math.floor(safePayload.deletedBytes)) : 0
+        const deletedByCategory = safePayload.deletedByCategory && typeof safePayload.deletedByCategory === 'object'
+          ? safePayload.deletedByCategory as Record<string, unknown>
+          : {}
+        const normalizedByCategory = Object.entries(deletedByCategory).reduce<Record<string, number>>((acc, [key, value]) => {
+          if (typeof value === 'number' && value > 0) acc[key] = Math.floor(value)
+          return acc
+        }, {})
+
         updated = withUpdatedMetricTotals(updated, (metrics) => ({
           ...metrics,
           totals: {
             ...metrics.totals,
-            itemsDeleted: metrics.totals.itemsDeleted + deletedCount
-          }
+            itemsDeleted: metrics.totals.itemsDeleted + deletedCount,
+            bytesDeleted: metrics.totals.bytesDeleted + deletedBytes
+          },
+          history: [
+            {
+              at: Date.now(),
+              deletedCount,
+              failedCount,
+              deletedBytes,
+              deletedByCategory: normalizedByCategory
+            },
+            ...metrics.history
+          ].slice(0, 30)
         }))
       }
 
       await deps.saveScanSettings(updated)
+    },
+
+    getCleanupInsights: async () => {
+      const settings = await deps.loadScanSettings()
+      return {
+        totals: {
+          cleanActions: settings.metrics.totals.cleanActions,
+          itemsDeleted: settings.metrics.totals.itemsDeleted,
+          bytesDeleted: settings.metrics.totals.bytesDeleted
+        },
+        timeline: settings.metrics.timeline,
+        recentRuns: settings.metrics.history.slice(0, 5)
+      }
     },
 
     markReminderSent: async (): Promise<void> => {

--- a/electron/core/ipc.ts
+++ b/electron/core/ipc.ts
@@ -45,13 +45,31 @@ function normalizeSettings(parsed: unknown): ScanSettings {
         scansCompleted: candidate.metrics?.totals?.scansCompleted ?? 0,
         cleanActions: candidate.metrics?.totals?.cleanActions ?? 0,
         itemsSelected: candidate.metrics?.totals?.itemsSelected ?? 0,
-        itemsDeleted: candidate.metrics?.totals?.itemsDeleted ?? 0
+        itemsDeleted: candidate.metrics?.totals?.itemsDeleted ?? 0,
+        bytesDeleted: candidate.metrics?.totals?.bytesDeleted ?? 0
       },
       timeline: {
         firstScanAt: candidate.metrics?.timeline?.firstScanAt,
         lastScanAt: candidate.metrics?.timeline?.lastScanAt,
         lastCleanAt: candidate.metrics?.timeline?.lastCleanAt
-      }
+      },
+      history: Array.isArray(candidate.metrics?.history)
+        ? candidate.metrics.history
+          .filter((entry) => entry && typeof entry === 'object')
+          .map((entry) => {
+            const record = entry as Record<string, unknown>
+            return {
+              at: typeof record.at === 'number' ? record.at : Date.now(),
+              deletedCount: typeof record.deletedCount === 'number' ? Math.max(0, Math.floor(record.deletedCount)) : 0,
+              failedCount: typeof record.failedCount === 'number' ? Math.max(0, Math.floor(record.failedCount)) : 0,
+              deletedBytes: typeof record.deletedBytes === 'number' ? Math.max(0, Math.floor(record.deletedBytes)) : 0,
+              deletedByCategory: record.deletedByCategory && typeof record.deletedByCategory === 'object'
+                ? record.deletedByCategory as Record<string, number>
+                : {}
+            }
+          })
+          .slice(0, 30)
+        : []
     }
   }
 }
@@ -161,6 +179,7 @@ export function registerIpcHandlers(getWindow: () => BrowserWindow | null): void
   ipcMain.handle('scan-settings:set-reminder-frequency', handlers.setReminderFrequency)
   ipcMain.handle('metrics:set-opt-in', handlers.setMetricsOptIn)
   ipcMain.handle('metrics:track-event', handlers.trackMetricEvent)
+  ipcMain.handle('metrics:get-cleanup-insights', handlers.getCleanupInsights)
   ipcMain.handle('delete-items', handlers.deleteItems)
 
   if (reminderInterval) clearInterval(reminderInterval)

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -9,6 +9,7 @@ contextBridge.exposeInMainWorld('cleaner', {
   setReminderFrequency: (frequency: string) => ipcRenderer.invoke('scan-settings:set-reminder-frequency', frequency),
   setMetricsOptIn: (enabled: boolean) => ipcRenderer.invoke('metrics:set-opt-in', enabled),
   trackMetricEvent: (eventName: string, payload?: Record<string, unknown>) => ipcRenderer.invoke('metrics:track-event', eventName, payload),
+  getCleanupInsights: () => ipcRenderer.invoke('metrics:get-cleanup-insights'),
   deleteItems: (paths: string[]) => ipcRenderer.invoke(
     'delete-items',
     Array.isArray(paths) ? paths.filter((p) => typeof p === 'string') : []

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { CleanupCategory, CleanupItem, CATEGORY_ORDER, CleanupPreset, ReminderFrequency, ScanProfile, SkippedScanTarget } from './types'
+import { CleanupCategory, CleanupInsights, CleanupItem, CATEGORY_ORDER, CleanupPreset, ReminderFrequency, ScanProfile, SkippedScanTarget } from './types'
 import { Header } from './components/Header'
 import { Sidebar } from './components/Sidebar'
 import { CategorySection } from './components/CategorySection'
 import { ScanScopeSelector } from './components/ScanScopeSelector'
+import { CleanupInsightsPanel } from './components/CleanupInsightsPanel'
 import { formatBytes } from './utils/format'
 import { Search, Loader2, FolderOpen, ShieldAlert } from 'lucide-react'
 
@@ -44,6 +45,7 @@ export default function App() {
   const [activePreset, setActivePreset] = useState<CleanupPreset | null>(null)
   const [reminderFrequency, setReminderFrequency] = useState<ReminderFrequency>('off')
   const [metricsEnabled, setMetricsEnabled] = useState(false)
+  const [cleanupInsights, setCleanupInsights] = useState<CleanupInsights | null>(null)
 
   useEffect(() => {
     if (!window.cleaner) return
@@ -68,6 +70,8 @@ export default function App() {
       setAuthorizedDirectories(settings.authorizedDirectories)
       setReminderFrequency(settings.reminder.frequency)
       setMetricsEnabled(settings.metrics.enabled)
+      const insights = await window.cleaner.getCleanupInsights()
+      setCleanupInsights(insights)
     }
 
     void loadSettings()
@@ -122,6 +126,8 @@ export default function App() {
     if (!window.cleaner) return
     const settings = await window.cleaner.setMetricsOptIn(enabled)
     setMetricsEnabled(settings.metrics.enabled)
+    const insights = await window.cleaner.getCleanupInsights()
+    setCleanupInsights(insights)
   }
 
   async function handleAddDirectory() {
@@ -164,13 +170,25 @@ export default function App() {
     }
 
     const { deleted, failed } = await window.cleaner.deleteItems(selectedList.map(i => i.path))
+    const failedPaths = new Set(failed.map((entry) => entry.path))
+    const deletedItems = selectedList.filter((item) => !failedPaths.has(item.path))
+    const deletedBytes = deletedItems.reduce((acc, item) => acc + item.size, 0)
+    const deletedByCategory = deletedItems.reduce<Partial<Record<CleanupCategory, number>>>((acc, item) => {
+      acc[item.category] = (acc[item.category] ?? 0) + item.size
+      return acc
+    }, {})
 
     if (metricsEnabled) {
       await window.cleaner.trackMetricEvent('clean_completed', {
         deletedCount: deleted,
-        failedCount: failed.length
+        failedCount: failed.length,
+        deletedBytes,
+        deletedByCategory
       })
     }
+
+    const insights = await window.cleaner.getCleanupInsights()
+    setCleanupInsights(insights)
 
     if (failed.length > 0) {
       const details = failed
@@ -267,6 +285,8 @@ export default function App() {
             onMetricsOptInChange={handleMetricsOptIn}
             disabled={isScanning}
           />
+
+          <CleanupInsightsPanel insights={cleanupInsights} />
 
           {items.length > 0 && (
             <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-3 mb-4">

--- a/src/components/CleanupInsightsPanel.tsx
+++ b/src/components/CleanupInsightsPanel.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { CleanupInsights } from '../types'
+import { formatBytes } from '../utils/format'
+import { Sparkles, Trash2, HardDrive, Clock3 } from 'lucide-react'
+
+function formatDate(value?: number): string {
+  if (!value) return '—'
+  return new Date(value).toLocaleDateString('pt-BR')
+}
+
+export function CleanupInsightsPanel({ insights }: { insights: CleanupInsights | null }) {
+  if (!insights) return null
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 mb-4 space-y-3">
+      <div className="flex items-center gap-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
+        <Sparkles className="w-4 h-4 text-blue-500" />
+        Resumo de impacto
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
+        <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-3">
+          <div className="text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-1">
+            <Trash2 className="w-3 h-3" /> Limpezas concluídas
+          </div>
+          <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">{insights.totals.cleanActions}</div>
+        </div>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-3">
+          <div className="text-xs text-gray-500 dark:text-gray-400">Itens removidos</div>
+          <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">{insights.totals.itemsDeleted}</div>
+        </div>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-3">
+          <div className="text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-1">
+            <HardDrive className="w-3 h-3" /> Espaço recuperado
+          </div>
+          <div className="text-lg font-semibold text-emerald-600 dark:text-emerald-300">{formatBytes(insights.totals.bytesDeleted)}</div>
+        </div>
+      </div>
+
+      <div className="text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-1">
+        <Clock3 className="w-3 h-3" />
+        Última limpeza: {formatDate(insights.timeline.lastCleanAt)}
+      </div>
+    </div>
+  )
+}

--- a/src/components/ItemRow.tsx
+++ b/src/components/ItemRow.tsx
@@ -26,7 +26,15 @@ export function ItemRow({ item, selected, toggle }: {
   selected: boolean,
   toggle: (id: string) => void
 }) {
+  const [showAllReasons, setShowAllReasons] = React.useState(false)
   const riskUi = RISK_UI[item.riskLevel]
+  const visibleReasons = showAllReasons ? item.recommendationReasons : item.recommendationReasons.slice(0, 3)
+
+  const recommendationLabel = item.riskLevel === 'low'
+    ? 'Recomendado para limpeza'
+    : item.riskLevel === 'medium'
+      ? 'Revisão manual sugerida'
+      : 'Atenção: alto risco'
 
   return (
     <div
@@ -107,13 +115,28 @@ export function ItemRow({ item, selected, toggle }: {
         <span className="inline-flex items-center px-2.5 py-1 rounded-full font-medium bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200">
           Score de segurança: {item.safetyScore}/100
         </span>
+        <span className="inline-flex items-center px-2.5 py-1 rounded-full font-medium bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300">
+          {recommendationLabel}
+        </span>
       </div>
 
       <ul className="space-y-1 text-xs text-gray-600 dark:text-gray-300 pl-1">
-        {item.recommendationReasons.slice(0, 3).map((reason, index) => (
+        {visibleReasons.map((reason, index) => (
           <li key={`${item.id}-reason-${index}`} className="leading-relaxed">• {reason}</li>
         ))}
       </ul>
+      {item.recommendationReasons.length > 3 && (
+        <button
+          type="button"
+          className="self-start text-xs text-blue-600 dark:text-blue-300 hover:underline"
+          onClick={(event) => {
+            event.stopPropagation()
+            setShowAllReasons((prev) => !prev)
+          }}
+        >
+          {showAllReasons ? 'Mostrar menos detalhes' : `Ver explicação completa (${item.recommendationReasons.length} pontos)`}
+        </button>
+      )}
     </div>
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,12 +43,36 @@ export interface LocalMetricsSettings {
     cleanActions: number
     itemsSelected: number
     itemsDeleted: number
+    bytesDeleted: number
   }
   timeline: {
     firstScanAt?: number
     lastScanAt?: number
     lastCleanAt?: number
   }
+  history: CleanupRunSummary[]
+}
+
+export interface CleanupRunSummary {
+  at: number
+  deletedCount: number
+  failedCount: number
+  deletedBytes: number
+  deletedByCategory: Partial<Record<CleanupCategory, number>>
+}
+
+export interface CleanupInsights {
+  totals: {
+    cleanActions: number
+    itemsDeleted: number
+    bytesDeleted: number
+  }
+  timeline: {
+    firstScanAt?: number
+    lastScanAt?: number
+    lastCleanAt?: number
+  }
+  recentRuns: CleanupRunSummary[]
 }
 
 export interface ReminderSettings {
@@ -75,6 +99,7 @@ declare global {
       setReminderFrequency: (frequency: ReminderFrequency) => Promise<ScanSettings>
       setMetricsOptIn: (enabled: boolean) => Promise<ScanSettings>
       trackMetricEvent: (eventName: string, payload?: Record<string, unknown>) => Promise<void>
+      getCleanupInsights: () => Promise<CleanupInsights>
       deleteItems: (paths: string[]) => Promise<{ deleted: number, failed: { path: string, message: string }[] }>
       onScanProgress: (cb: (progress: number) => void) => () => void
       onReminder: (cb: (payload: { frequency: ReminderFrequency; dueAt: number }) => void) => () => void


### PR DESCRIPTION
### Motivation

- Capture and surface richer cleanup metrics (bytes removed, per-run history and per-category breakdown) so the app can show impact of cleans and track recent runs.
- Expose an IPC API to read aggregated cleanup insights for the renderer and render a small summary UI so users can see recovered space and recent clean counts.

### Description

- Extend metrics shape by adding `bytesDeleted` and a `history` array with `CleanupRunSummary` entries, and persist these fields in settings normalization and defaults (`DEFAULT_SETTINGS`).
- Update IPC handlers to record `deletedBytes`, `failedCount`, and normalized `deletedByCategory` on `clean_completed`, append a capped run summary to `metrics.history`, and add a new handler `getCleanupInsights` that returns summarized totals, timeline and recent runs.
- Wire the new IPC method through the preload (`getCleanupInsights`) and register `metrics:get-cleanup-insights` in the main process IPC registration.
- Add a `CleanupInsightsPanel` component and integrate it into `App.tsx`, fetch insights on load and after metric opt-in / clean completion, and improve `ItemRow` UI to show a recommendation label and expandable recommendation reasons.

### Testing

- Updated existing IPC smoke test (`electron/core/__tests__/ipc-smoke.test.ts`) to account for the new `bytesDeleted` and `history` fields and exercised `createIpcHandlers` progress and scan flows.  
- Ran the unit/integration test suite (including the modified `ipc-smoke.test.ts`) and the tests completed successfully.  
- Manually exercised the new IPC path from the renderer during development to ensure the `CleanupInsightsPanel` receives and renders the summarized totals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41c31b2f883309ce85fa438f92ed1)