### PR TITLE
feat(tray): enhance tray menu with quick actions and renderer integration

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,10 +1,11 @@
-import { app, BrowserWindow } from 'electron'
+import { app, BrowserWindow, Menu, nativeImage, shell, Tray } from 'electron'
 import path from 'node:path'
 import { createMainWindow } from './core/window.js'
 import { registerIpcHandlers } from './core/ipc.js'
 
 const isDev = !app.isPackaged || !!process.env.VITE_DEV_SERVER_URL
 let mainWindow: BrowserWindow | null = null
+let tray: Tray | null = null
 
 async function createWindow() {
   mainWindow = createMainWindow()
@@ -19,14 +20,92 @@ async function createWindow() {
   await mainWindow.loadFile(indexHtml)
 }
 
+function showMainWindow(): void {
+  if (!mainWindow) {
+    void createWindow()
+    return
+  }
+
+  if (mainWindow.isMinimized()) mainWindow.restore()
+  mainWindow.show()
+  mainWindow.focus()
+}
+
+function sendTrayAction(action: 'scan-quick' | 'scan-safe' | 'scan-complete' | 'reminder-weekly' | 'reminder-monthly' | 'toggle-theme') {
+  showMainWindow()
+  mainWindow?.webContents.send('tray-action', action)
+}
+
+function createTray(): void {
+  if (tray) return
+
+  const iconPath = path.join(process.cwd(), 'build', 'icon.png')
+  const icon = nativeImage.createFromPath(iconPath).resize({ width: 18, height: 18 })
+
+  tray = new Tray(icon)
+  tray.setToolTip('CleanMyMac Pro · Limpeza inteligente em 1 clique')
+
+  const contextMenu = Menu.buildFromTemplate([
+    { label: '✨ CleanMyMac Pro', enabled: false },
+    { type: 'separator' },
+    {
+      label: '🚀 Executar análise rápida',
+      click: () => sendTrayAction('scan-quick')
+    },
+    {
+      label: '🛡️ Executar análise segura',
+      click: () => sendTrayAction('scan-safe')
+    },
+    {
+      label: '🔬 Executar análise completa',
+      click: () => sendTrayAction('scan-complete')
+    },
+    { type: 'separator' },
+    {
+      label: '⏰ Lembrete semanal',
+      click: () => sendTrayAction('reminder-weekly')
+    },
+    {
+      label: '📅 Lembrete mensal',
+      click: () => sendTrayAction('reminder-monthly')
+    },
+    {
+      label: '🌓 Alternar tema',
+      click: () => sendTrayAction('toggle-theme')
+    },
+    { type: 'separator' },
+    {
+      label: '📁 Abrir dados do app',
+      click: () => {
+        void shell.openPath(app.getPath('userData'))
+      }
+    },
+    {
+      label: '🪟 Mostrar janela',
+      click: () => showMainWindow()
+    },
+    {
+      label: '👋 Fechar CleanMyMac Pro',
+      click: () => app.quit()
+    }
+  ])
+
+  tray.setContextMenu(contextMenu)
+  tray.on('double-click', showMainWindow)
+}
+
 app.whenReady().then(async () => {
   await createWindow()
+  createTray()
   registerIpcHandlers(() => mainWindow)
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       void createWindow()
+      return
     }
+
+    showMainWindow()
   })
 })
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -23,5 +23,10 @@ contextBridge.exposeInMainWorld('cleaner', {
     const handler = (_: unknown, value: { frequency: 'off' | 'weekly' | 'monthly'; dueAt: number }) => cb(value)
     ipcRenderer.on('scan-reminder', handler)
     return () => ipcRenderer.removeListener('scan-reminder', handler)
+  },
+  onTrayAction: (cb: (action: 'scan-quick' | 'scan-safe' | 'scan-complete' | 'reminder-weekly' | 'reminder-monthly' | 'toggle-theme') => void) => {
+    const handler = (_: unknown, value: 'scan-quick' | 'scan-safe' | 'scan-complete' | 'reminder-weekly' | 'reminder-monthly' | 'toggle-theme') => cb(value)
+    ipcRenderer.on('tray-action', handler)
+    return () => ipcRenderer.removeListener('tray-action', handler)
   }
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { CleanupCategory, CleanupInsights, CleanupItem, CATEGORY_ORDER, CleanupPreset, ReminderFrequency, ScanProfile, SkippedScanTarget } from './types'
+import { CleanupCategory, CleanupInsights, CleanupItem, CATEGORY_ORDER, CleanupPreset, ReminderFrequency, ScanProfile, SkippedScanTarget, TrayAction } from './types'
 import { Header } from './components/Header'
 import { Sidebar } from './components/Sidebar'
 import { CategorySection } from './components/CategorySection'
@@ -59,6 +59,48 @@ export default function App() {
       const dueDate = new Date(payload.dueAt).toLocaleDateString('pt-BR')
       alert(`Lembrete local: sua análise ${payload.frequency === 'weekly' ? 'semanal' : 'mensal'} está pendente desde ${dueDate}.`)
     })
+    return () => off && off()
+  }, [])
+
+  useEffect(() => {
+    if (!window.cleaner) return
+
+    const applyTrayAction = async (action: TrayAction) => {
+      if (action === 'scan-quick') {
+        await handleProfileChange('quick')
+        await handleScan()
+        return
+      }
+
+      if (action === 'scan-safe') {
+        await handleProfileChange('safe')
+        await handleScan()
+        return
+      }
+
+      if (action === 'scan-complete') {
+        await handleProfileChange('complete')
+        await handleScan()
+        return
+      }
+
+      if (action === 'reminder-weekly') {
+        await handleReminderChange('weekly')
+        return
+      }
+
+      if (action === 'reminder-monthly') {
+        await handleReminderChange('monthly')
+        return
+      }
+
+      document.documentElement.classList.toggle('dark')
+    }
+
+    const off = window.cleaner.onTrayAction((action) => {
+      void applyTrayAction(action)
+    })
+
     return () => off && off()
   }, [])
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type ScanProfile = 'quick' | 'safe' | 'complete'
 export type RiskLevel = 'low' | 'medium' | 'high'
 export type CleanupPreset = 'conservative' | 'balanced' | 'aggressive'
 export type ReminderFrequency = 'off' | 'weekly' | 'monthly'
+export type TrayAction = 'scan-quick' | 'scan-safe' | 'scan-complete' | 'reminder-weekly' | 'reminder-monthly' | 'toggle-theme'
 
 export interface CategoryInfo {
   id: CleanupCategory
@@ -103,6 +104,7 @@ declare global {
       deleteItems: (paths: string[]) => Promise<{ deleted: number, failed: { path: string, message: string }[] }>
       onScanProgress: (cb: (progress: number) => void) => () => void
       onReminder: (cb: (payload: { frequency: ReminderFrequency; dueAt: number }) => void) => () => void
+      onTrayAction: (cb: (action: TrayAction) => void) => () => void
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a more attractive and useful system tray menu so users can trigger common actions quickly without opening the main window.
- Allow tray actions to control the renderer (start scans, change reminders, toggle theme) in a typed, safe way.

### Description
- Add a tray implementation in the main process (`electron/main.ts`) with an attractive context menu (emoji labels, grouped sections, improved tooltip), double-click to show window, and helper functions `createTray`, `showMainWindow`, and `sendTrayAction` to forward actions to the renderer via IPC.
- Expose a new IPC channel `tray-action` in the preload (`electron/preload.ts`) by adding `onTrayAction` to the `window.cleaner` API so the renderer can subscribe to tray commands.
- Add a shared `TrayAction` type and `onTrayAction` signature to `src/types.ts` for end-to-end typing of tray messages.
- Subscribe to tray commands in the React app (`src/App.tsx`) and implement handlers that switch scan profile + trigger `scanAll`, set reminder frequency, or toggle theme as appropriate.

### Testing
- Ran the production build with `npm run build` (runs `vite build` and TypeScript compile for Electron) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e42c8ee3c48330b923e9b2a8eae069)